### PR TITLE
Ignore .idea dir (for WebStorm users)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist
 /node_modules
 /packages/*/dist
+/.idea


### PR DESCRIPTION
I would just add the `.idea` directory to the ignored directories. This directory is created by WebStorm to store local configuration/caches and it should not be committed.