### PR TITLE
Adding inspection packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm run dev
 ```
 
 ### How to test
-Ensure the Postgres server and the rspository server are both running.
+Ensure the Postgres server and the repository server are both running.
 Then do
 
 ```
@@ -68,6 +68,6 @@ The core repository
 Tests for the core package
 
 ## CI
-In GitHub actions a postgres server is started on a host named `postres`.
+In GitHub actions a postgres server is started on a host named `postgres`.
 In you local development environment this hostname is also being used.
 You need to ensure that this hostname points to the postgres server. 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "workspaces": [
     "./packages/dbadmin",
-    "./packages/core",
     "./packages/inspection",
+    "./packages/core",
     "./packages/test"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": " npm run build -w packages",
     "lint": "npm run lint -w packages",
     "test": "npm run test -w packages",
+    "dev": "npm run dev -w @lionweb/repository-core",
     "database": "node packages/database-mgt/dist/tools/database",
     "npm-install-local": "npm config set registry http://localhost:4873 && npm install && npm config set registry https://registry.npmjs.com",
     "npm-install": "npm config set registry https://registry.npmjs.com && npm install"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "eslint": "8.56.0",
     "chai": "4.3.10",
     "mocha": "10.2.0",
-    "prettier": "3.1.0",
     "ts-node": "10.9.2",
     "typescript": "5.2.2"
   },
   "workspaces": [
     "./packages/dbadmin",
     "./packages/core",
+    "./packages/inspection",
     "./packages/test"
   ]
 }

--- a/packages/core/.env
+++ b/packages/core/.env
@@ -1,5 +1,5 @@
 # Postgres configuration
-PGHOST=postgres
+PGHOST=localhost
 PGUSER=postgres
 PGDATABASE=lionweb_test
 PGPASSWORD=lionweb

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,12 +32,12 @@
     "eslint": "8.56.0",
     "chai": "4.3.10",
     "mocha": "10.2.0",
-    "prettier": "3.1.0",
     "ts-node": "10.9.2",
     "typescript": "5.2.2"
   },
   "dependencies": {
     "@lionweb/repository-dbadmin": "0.1.0",
+    "@lionweb/repository-inspection": "0.1.0",
     "@lionweb/validation": "0.6.0-beta.4",
     "@types/express": "4.17.21",
     "body-parser": "1.20.2",

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -7,6 +7,7 @@ import { LIONWEB_BULK_API } from "./controllers/LionWebBulkApi.js"
 import cors from "cors"
 import { registerDBAdmin } from "@lionweb/repository-dbadmin"
 import { dbConnection } from "./database/DbConnection.js"
+import { registerInspection } from "@lionweb/repository-inspection"
 
 dotenv.config()
 
@@ -31,6 +32,7 @@ app.post("/bulk/retrieve", LIONWEB_BULK_API.retrieve)
 
 app.post("/getNodeTree", ADDITIONAL_API.getNodeTree)
 registerDBAdmin(app, dbConnection)
+registerInspection(app, dbConnection)
 
 const httpServer = http.createServer(app)
 

--- a/packages/inspection/.eslintrc.cjs
+++ b/packages/inspection/.eslintrc.cjs
@@ -1,0 +1,4 @@
+/* eslint-env node */
+module.exports = {
+    extends: "../.eslintrc.cjs",
+}

--- a/packages/inspection/.prettierrc
+++ b/packages/inspection/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 140,
+  "tabWidth": 4,
+  "semi": false,
+  "arrowParens": "avoid",
+  "trailingComma": "none"
+}

--- a/packages/inspection/package.json
+++ b/packages/inspection/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@lionweb/repository-inspection",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Inspection routes for the lionweb repository",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "type": "module",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LionWeb-io/lionweb-repository.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LionWeb-io/lionweb-repository/issues"
+  },
+  "scripts": {
+    "build": "rm -rf dist/ && tsc",
+    "cleanup": "rm -rf ./node_modules",
+    "lint": "eslint src",
+    "test": "echo No tests in repository-dbadmin"
+  }
+}

--- a/packages/inspection/package.json
+++ b/packages/inspection/package.json
@@ -19,6 +19,6 @@
     "build": "rm -rf dist/ && tsc",
     "cleanup": "rm -rf ./node_modules",
     "lint": "eslint src",
-    "test": "echo No tests in repository-dbadmin"
+    "test": "echo No tests in repository-inspection"
   }
 }

--- a/packages/inspection/src/controllers/InspectionApi.ts
+++ b/packages/inspection/src/controllers/InspectionApi.ts
@@ -3,14 +3,21 @@ import { INSPECTION_WORKER } from "../database/InspectionApiWorker.js";
 import { INSPECTION_QUERIES } from "../database/InspectionQueries.js"
 
 export interface InspectionApi {
-    nodesByConcept(req: Request, res: Response): void
+    nodesByClassifier(req: Request, res: Response): void
+    nodesByLanguage(req: Request, res: Response): void
 }
 
 class InspectionApiImpl implements InspectionApi {
 
-    async nodesByConcept(req: e.Request, res: e.Response) {
-        const sql = INSPECTION_QUERIES.nodesByConcept();
-        await INSPECTION_WORKER.nodesByConcept(sql)
+    async nodesByClassifier(req: e.Request, res: e.Response) {
+        const sql = INSPECTION_QUERIES.nodesByClassifier();
+        await INSPECTION_WORKER.nodesByClassifier(sql)
+        throw new Error("Not implemented");
+    }
+
+    async nodesByLanguage(req: e.Request, res: e.Response) {
+        const sql = INSPECTION_QUERIES.nodesByLanguage();
+        await INSPECTION_WORKER.nodesByLanguage(sql)
         throw new Error("Not implemented");
     }
 }

--- a/packages/inspection/src/controllers/InspectionApi.ts
+++ b/packages/inspection/src/controllers/InspectionApi.ts
@@ -1,0 +1,21 @@
+import e, { Request, Response } from "express"
+import { INSPECTION_WORKER } from "../database/InspectionApiWorker.js";
+import { INSPECTION_QUERIES } from "../database/InspectionQueries.js"
+
+export interface InspectionApi {
+    nodesByConcept(req: Request, res: Response): void
+}
+
+class InspectionApiImpl implements InspectionApi {
+
+    async nodesByConcept(req: e.Request, res: e.Response) {
+        const sql = INSPECTION_QUERIES.nodesByConcept();
+        await INSPECTION_WORKER.nodesByConcept(sql)
+        throw new Error("Not implemented");
+    }
+}
+
+export function createInspectionApi() : InspectionApi {
+    return new InspectionApiImpl();
+}
+

--- a/packages/inspection/src/controllers/InspectionApi.ts
+++ b/packages/inspection/src/controllers/InspectionApi.ts
@@ -11,14 +11,14 @@ class InspectionApiImpl implements InspectionApi {
 
     async nodesByClassifier(req: e.Request, res: e.Response) {
         const sql = INSPECTION_QUERIES.nodesByClassifier();
-        await INSPECTION_WORKER.nodesByClassifier(sql)
-        throw new Error("Not implemented");
+        const queryResult = await INSPECTION_WORKER.nodesByClassifier(sql)
+        res.send(queryResult)
     }
 
     async nodesByLanguage(req: e.Request, res: e.Response) {
         const sql = INSPECTION_QUERIES.nodesByLanguage();
-        await INSPECTION_WORKER.nodesByLanguage(sql)
-        throw new Error("Not implemented");
+        const queryResult = await INSPECTION_WORKER.nodesByLanguage(sql)
+        res.send(queryResult)
     }
 }
 

--- a/packages/inspection/src/database/InspectionApiWorker.ts
+++ b/packages/inspection/src/database/InspectionApiWorker.ts
@@ -1,0 +1,22 @@
+import pgPromise from "pg-promise"
+import pg from "pg-promise/typescript/pg-subset.js"
+
+
+/**
+ * Implementations of the additional non-LionWeb methods for inspection the content of the repository.
+ */
+export class InspectionApiWorker {
+
+    constructor(private dbConnection: pgPromise.IDatabase<object, pg.IClient>) {
+    }
+
+    async nodesByConcept(sql: string) {
+        return await this.dbConnection.query(sql)
+    }
+}
+
+export function createInspectionApiWorker(dbConnection: pgPromise.IDatabase<object , pg.IClient>) {
+    INSPECTION_WORKER = new InspectionApiWorker(dbConnection);
+}
+
+export let INSPECTION_WORKER: InspectionApiWorker

--- a/packages/inspection/src/database/InspectionApiWorker.ts
+++ b/packages/inspection/src/database/InspectionApiWorker.ts
@@ -1,6 +1,16 @@
 import pgPromise from "pg-promise"
 import pg from "pg-promise/typescript/pg-subset.js"
 
+export interface LanguageNodes {
+    language: string,
+    ids: [string]
+}
+
+export interface ClassifierNodes {
+    language: string,
+    classifier: string,
+    ids: [string]
+}
 
 /**
  * Implementations of the additional non-LionWeb methods for inspection the content of the repository.
@@ -11,11 +21,22 @@ export class InspectionApiWorker {
     }
 
     async nodesByLanguage(sql: string) {
-        return await this.dbConnection.query(sql)
+        return (await this.dbConnection.query(sql) as [object]).map(el => {
+            return {
+                "language": el["classifier_language"],
+                "ids": el["ids"].split(",")
+            } as LanguageNodes
+        })
     }
 
     async nodesByClassifier(sql: string) {
-        return await this.dbConnection.query(sql)
+        return (await this.dbConnection.query(sql) as [object]).map(el => {
+            return {
+                "language": el["classifier_language"],
+                "classifier": el["classifier_key"],
+                "ids": el["ids"].split(",")
+            } as ClassifierNodes
+        })
     }
 }
 

--- a/packages/inspection/src/database/InspectionApiWorker.ts
+++ b/packages/inspection/src/database/InspectionApiWorker.ts
@@ -10,7 +10,11 @@ export class InspectionApiWorker {
     constructor(private dbConnection: pgPromise.IDatabase<object, pg.IClient>) {
     }
 
-    async nodesByConcept(sql: string) {
+    async nodesByLanguage(sql: string) {
+        return await this.dbConnection.query(sql)
+    }
+
+    async nodesByClassifier(sql: string) {
         return await this.dbConnection.query(sql)
     }
 }

--- a/packages/inspection/src/database/InspectionQueries.ts
+++ b/packages/inspection/src/database/InspectionQueries.ts
@@ -1,0 +1,13 @@
+/**
+ * Database functions.
+ */
+class InspectionQueries {
+    constructor() {
+    }
+
+    nodesByConcept() : string {
+        throw new Error("Not implemented")
+    }
+}
+
+export const INSPECTION_QUERIES = new InspectionQueries()

--- a/packages/inspection/src/database/InspectionQueries.ts
+++ b/packages/inspection/src/database/InspectionQueries.ts
@@ -6,12 +6,12 @@ class InspectionQueries {
     }
 
     nodesByClassifier() : string {
-        return "select classifier_language, classifier_key, string_agg(id, ',') " +
+        return "select classifier_language, classifier_key, string_agg(id, ',') AS ids " +
             "from lionweb_nodes group by classifier_language, classifier_key;"
     }
 
     nodesByLanguage() : string {
-        return "select classifier_language, string_agg(id, ',') " +
+        return "select classifier_language, string_agg(id, ',') AS ids " +
             "from lionweb_nodes group by classifier_language;"
     }
 }

--- a/packages/inspection/src/database/InspectionQueries.ts
+++ b/packages/inspection/src/database/InspectionQueries.ts
@@ -5,8 +5,14 @@ class InspectionQueries {
     constructor() {
     }
 
-    nodesByConcept() : string {
-        throw new Error("Not implemented")
+    nodesByClassifier() : string {
+        return "select classifier_language, classifier_key, string_agg(id, ',') " +
+            "from lionweb_nodes group by classifier_language, classifier_key;"
+    }
+
+    nodesByLanguage() : string {
+        return "select classifier_language, string_agg(id, ',') " +
+            "from lionweb_nodes group by classifier_language;"
     }
 }
 

--- a/packages/inspection/src/index.ts
+++ b/packages/inspection/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./main.js"

--- a/packages/inspection/src/main.ts
+++ b/packages/inspection/src/main.ts
@@ -8,6 +8,6 @@ export function registerInspection(app: Express, dbConnection: pgPromise.IDataba
     console.log("Registering DB Admin");
     createInspectionApiWorker(dbConnection)
     const inspectionApi: InspectionApi = createInspectionApi();
-    app.post("/inspection/nodesByClassifier", inspectionApi.nodesByClassifier)
-    app.post("/inspection/nodesByLanguage", inspectionApi.nodesByLanguage)
+    app.get("/inspection/nodesByClassifier", inspectionApi.nodesByClassifier)
+    app.get("/inspection/nodesByLanguage", inspectionApi.nodesByLanguage)
 }

--- a/packages/inspection/src/main.ts
+++ b/packages/inspection/src/main.ts
@@ -8,5 +8,6 @@ export function registerInspection(app: Express, dbConnection: pgPromise.IDataba
     console.log("Registering DB Admin");
     createInspectionApiWorker(dbConnection)
     const inspectionApi: InspectionApi = createInspectionApi();
-    app.post("/inspection/nodesByConcept", inspectionApi.nodesByConcept)
+    app.post("/inspection/nodesByClassifier", inspectionApi.nodesByClassifier)
+    app.post("/inspection/nodesByLanguage", inspectionApi.nodesByLanguage)
 }

--- a/packages/inspection/src/main.ts
+++ b/packages/inspection/src/main.ts
@@ -1,0 +1,12 @@
+import { Express } from "express"
+import pgPromise from "pg-promise"
+import pg from "pg-promise/typescript/pg-subset.js"
+import { createInspectionApiWorker } from "./database/InspectionApiWorker.js"
+import { createInspectionApi, InspectionApi } from "./controllers/InspectionApi.js"
+
+export function registerInspection(app: Express, dbConnection: pgPromise.IDatabase<object , pg.IClient>) {
+    console.log("Registering DB Admin");
+    createInspectionApiWorker(dbConnection)
+    const inspectionApi: InspectionApi = createInspectionApi();
+    app.post("/inspection/nodesByConcept", inspectionApi.nodesByConcept)
+}

--- a/packages/inspection/tsconfig.json
+++ b/packages/inspection/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "resolveJsonModule": true,                        /* Enable importing .json files */
+    "sourceRoot": "./src"
+  }
+}

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -20,7 +20,7 @@
     "cleanup": "rm -rf ./node_modules",
     "lint": "eslint src",
     "manualtest": "node dist/test/ManualTests.js",
-    "test": "mocha ./dist/test/tests.js"
+    "test": "mocha ./dist/test/tests.js ./dist/test/inspectionTests.js"
   },
   "devDependencies": {
     "prettier": "3.1.0",
@@ -31,7 +31,6 @@
     "eslint": "8.56.0",
     "chai": "4.3.10",
     "mocha": "10.2.0",
-    "prettier": "3.1.0",
     "ts-node": "10.9.2",
     "typescript": "5.2.2"
   },

--- a/packages/test/src/test/RepositoryClient.ts
+++ b/packages/test/src/test/RepositoryClient.ts
@@ -73,7 +73,16 @@ export class RepositoryClient {
     async testNodesByLanguage() {
         console.log(`test.testNodesByLanguage`)
         const startTime = performance.now()
-        const x = await this.getWithTimeout(`inspections/nodesByLanguage`, { body: {  }, params: `` })
+        const x = await this.getWithTimeout(`inspection/nodesByLanguage`, { body: {  }, params: `` })
+        const endTime = performance.now()
+        console.log(`Call to query took ${endTime - startTime} milliseconds`)
+        return x
+    }
+
+    async testNodesByClassifier() {
+        console.log(`test.testNodesByClassifier`)
+        const startTime = performance.now()
+        const x = await this.getWithTimeout(`inspection/nodesByClassifier`, { body: {  }, params: `` })
         const endTime = performance.now()
         console.log(`Call to query took ${endTime - startTime} milliseconds`)
         return x

--- a/packages/test/src/test/RepositoryClient.ts
+++ b/packages/test/src/test/RepositoryClient.ts
@@ -70,6 +70,15 @@ export class RepositoryClient {
         return x
     }
 
+    async testNodesByLanguage() {
+        console.log(`test.testNodesByLanguage`)
+        const startTime = performance.now()
+        const x = await this.getWithTimeout(`inspections/nodesByLanguage`, { body: {  }, params: `` })
+        const endTime = performance.now()
+        console.log(`Call to query took ${endTime - startTime} milliseconds`)
+        return x
+    }
+
     async getWithTimeout<T>(method: string, parameters: { body: unknown; params: string }): Promise<T> {
         const params = this.findParams(parameters.params)
         // console.log("getWithTimeout Params = " + parameters.params);

--- a/packages/test/src/test/inspectionTests.ts
+++ b/packages/test/src/test/inspectionTests.ts
@@ -1,0 +1,33 @@
+import { LanguageChange, LionWebJsonChunk, LionWebJsonChunkWrapper, LionWebJsonDiff } from "@lionweb/validation"
+import { assert } from "chai"
+import { RepositoryClient } from "./RepositoryClient.js"
+
+const { deepEqual } = assert
+import sm from "source-map-support"
+
+sm.install()
+
+describe("Repository tests for inspection APIs", () => {
+    const t = new RepositoryClient()
+    let jsonModel: LionWebJsonChunk
+
+    beforeEach("a", async function () {
+        jsonModel = t.readModel("./src/test/data/Disk_A.json") as LionWebJsonChunk
+        await t.init()
+        await t.testStore(jsonModel)
+    })
+
+    it("nodes by language", async () => {
+        const retrieve = (await t.testNodesByLanguage())
+        console.log("FOO", retrieve)
+        // console.log("JSON MODEL ORIGINAL")
+        // printChunk(jsonModel)
+        // console.log("JSON MODEL RETRIEVED")
+        // printChunk(retrieve.json  as LionWebJsonChunk)
+        // const diff = new LionWebJsonDiff()
+        // diff.diffLwChunk(jsonModel, retrieve.json  as LionWebJsonChunk)
+        // deepEqual(diff.diffResult.changes, [])
+    })
+
+
+})

--- a/packages/test/src/test/inspectionTests.ts
+++ b/packages/test/src/test/inspectionTests.ts
@@ -18,16 +18,54 @@ describe("Repository tests for inspection APIs", () => {
     })
 
     it("nodes by language", async () => {
-        const retrieve = (await t.testNodesByLanguage())
-        console.log("FOO", retrieve)
-        // console.log("JSON MODEL ORIGINAL")
-        // printChunk(jsonModel)
-        // console.log("JSON MODEL RETRIEVED")
-        // printChunk(retrieve.json  as LionWebJsonChunk)
-        // const diff = new LionWebJsonDiff()
-        // diff.diffLwChunk(jsonModel, retrieve.json  as LionWebJsonChunk)
-        // deepEqual(diff.diffResult.changes, [])
+        const result = (await t.testNodesByLanguage())
+        deepEqual(result,  [
+                {
+                    language: '-default-key-FileSystem',
+                    ids: [
+                        'ID-2',  'ID-3',  'ID-4',
+                        'ID-8',  'ID-9',  'ID-10',
+                        'ID-5',  'ID-11', 'ID-12',
+                        'ID-13', 'ID-14', 'ID-15',
+                        'ID-6',  'ID-7',  'ANN-1'
+                    ]
+                }
+            ]
+        )
     })
 
+    it("nodes by classifier", async () => {
+        const result = (await t.testNodesByClassifier())
+        deepEqual(result,  [
+                {
+                    "language": "-default-key-FileSystem",
+                    "classifier": "Disk-key",
+                    "ids": [
+                        "ID-2"
+                    ]
+                },
+                {
+                    "language": "-default-key-FileSystem",
+                    "classifier": "Folder-key",
+                    "ids": [
+                        "ID-3",
+                        "ID-4",
+                        "ID-8",
+                        "ID-9",
+                        "ID-10",
+                        "ID-5",
+                        "ID-11",
+                        "ID-12",
+                        "ID-13",
+                        "ID-14",
+                        "ID-15",
+                        "ID-6",
+                        "ID-7",
+                        "ANN-1"
+                    ]
+                }
+            ]
+        )
+    })
 
 })


### PR DESCRIPTION
This package provides routes to get basic statistics about the content of the repository.

At this time it exposes two routes: one to get all nodes by language and one to get all nodes by classifier.

My main doubt is around tests: I inserted tests in the tests package, but I am not sure if I should instead create a separate package for the tests that are specific for this package.