### PR TITLE
Accept larger bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ cd packages/core
 npm run dev
 ```
 
+For more information on how to configure the repository, please check [configuration.md](configuration.md).
+
 ### How to test
 Ensure the Postgres server and the repository server are both running.
 Then do

--- a/configuration.md
+++ b/configuration.md
@@ -1,0 +1,16 @@
+# Configuration
+
+Environment variables can be used to configure the project:
+
+## Database configuration
+
+* **PGHOST** (default `postgres`): The address at which the Postgres server can be reached
+* **PGPORT** (default `5432`): The port at which the Postgres server can be reached
+* **PGDATABASE** (default `lionweb_test`): The name of the Postgres database to be used within the Postgres server
+* **PGUSER** (default `postgres`): The username used to connect to the Postgres server
+* **PGPASSWORD** (default `lionweb`): The password used to connect to the Postgres server
+
+## Node application configuration
+
+* **NODE_PORT** (default `3005`): Port at which the lionweb repository can be reached
+* **BODY_LIMIT** (default `50mb`): Maximum size of the body requests accepted by the lionweb repository

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -24,7 +24,7 @@ app.use(
     }),
 )
 app.use(bodyParser.urlencoded({ extended: false }))
-app.use(bodyParser.json())
+app.use(bodyParser.json({limit: process.env.BODY_LIMIT || '50mb'}))
 
 app.get("/bulk/partitions", LIONWEB_BULK_API.partitions)
 app.post("/bulk/store", LIONWEB_BULK_API.store)

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -36,6 +36,7 @@ registerInspection(app, dbConnection)
 
 const httpServer = http.createServer(app)
 
-httpServer.listen(3005, () => {
-    console.log(`Server is running at port 3005 =========================================================`)
+const serverPort = parseInt(process.env.NODE_PORT || "3005")
+httpServer.listen(serverPort, () => {
+    console.log(`Server is running at port ${serverPort} =========================================================`)
 })

--- a/scripts/kill-server.sh
+++ b/scripts/kill-server.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
-pid=$(lsof -i4TCP:3005 -Fp | grep ^p | sed "s/p//")
+if [[ -z "${NODE_PORT}" ]]; then
+  PORT="3005"
+else
+  PORT="${NODE_PORT}"
+fi
+
+pid=$(lsof -i4TCP:$PORT -Fp | grep ^p | sed "s/p//")
 kill $pid


### PR DESCRIPTION
This should fix #22 . It increases the default limit for the size of the body of incoming requests. It also make it possible to change the limit through an environment variable. That variable and the other existing environment variables are then documented in a new file called `configuration.md`.

I would still need to verify that compression works. I think this server would automatically handle compressed bodies of incoming requests, but I am running into issues on the client side. However that is an orthogonal matter to ensuring that larger bodies are accepted.