### PR TITLE
In case of exception while serving a request, return 500

### DIFF
--- a/packages/dbadmin/src/tools/functions.ts
+++ b/packages/dbadmin/src/tools/functions.ts
@@ -5,7 +5,9 @@ export function runWithTry( func: (req: Request, res: Response) => void): (req: 
         try {
             await func(req, res)
         } catch(e) {
-            console.log("Exception " + e.message)
+            console.log(`Exception while serving request for ${req.url}: ${e.message}`)
+            res.status(500)
+            res.send(`Exception while serving request for ${req.url}: ${e.message}`)
         }
     }
 }


### PR DESCRIPTION
In case of exceptions we currently print a message but the HTTP request being served remain hanging.
With this PR we return a 500 code and a message explaining why the serve failed.

Fix #25 