### PR TITLE
Fix database tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "setup": "npm run setup -w packages --if-present",
     "test": "npm run test -w packages --if-present",
     "release": "npm run release -w packages --if-present",
-    "database": "node packages/database-mgt/dist/tools/database",
+    "database": "node packages/dbadmin/dist/tools/database",
     "npm-install-local": "npm config set registry http://localhost:4873 && npm install",
     "npm-install": "npm config set registry https://registry.npmjs.com && npm install"
   },

--- a/packages/dbadmin/src/tools/configuration.ts
+++ b/packages/dbadmin/src/tools/configuration.ts
@@ -1,0 +1,3 @@
+export const PGHOST = process.env.PGHOST || "postgres"
+export const PGUSER = process.env.PGUSER || "postgres"
+export const PGDATABASE = process.env.PGDATABASE ||  "lionweb_test"

--- a/packages/dbadmin/src/tools/create-database-sql.ts
+++ b/packages/dbadmin/src/tools/create-database-sql.ts
@@ -1,7 +1,9 @@
+import {PGDATABASE, PGUSER} from "./configuration.js";
+
 export const CREATE_DATABASE_SQL: string = `
-CREATE DATABASE lionweb_test
+CREATE DATABASE ${PGDATABASE}
     WITH
-    OWNER = postgres
+    OWNER = '${PGUSER}'
     ENCODING = 'UTF8'
     LC_COLLATE = 'en_US.utf8'
     LC_CTYPE = 'en_US.utf8'
@@ -10,7 +12,7 @@ CREATE DATABASE lionweb_test
     CONNECTION LIMIT = -1
     IS_TEMPLATE = False;
 
-GRANT TEMPORARY, CONNECT ON DATABASE lionweb_test TO PUBLIC;
+GRANT TEMPORARY, CONNECT ON DATABASE ${PGDATABASE} TO PUBLIC;
 
-GRANT ALL ON DATABASE lionweb_test TO postgres;
+GRANT ALL ON DATABASE ${PGDATABASE} TO ${PGUSER};
 `

--- a/packages/dbadmin/src/tools/database.ts
+++ b/packages/dbadmin/src/tools/database.ts
@@ -1,4 +1,5 @@
 import pgPromise from "pg-promise"
+import {PGDATABASE, PGHOST, PGUSER} from "./configuration.js";
 import { CREATE_DATABASE_SQL } from "./create-database-sql.js"
 import { INIT_TABLES_SQL } from "./init-tables-sql.js"
 
@@ -9,17 +10,18 @@ type PostgresConfig = {
     database?: string
     password: string
 }
+
 const CREATE_CONFIG: PostgresConfig = {
-    host: process.env.PGHOST || "postgres",
+    host: PGHOST,
     port: parseInt(process.env.PGPORT || "5432", 10),
-    user: process.env.PGUSER || "postgres",
+    user: PGUSER,
     password: process.env.PGPASSWORD || "lionweb"
 }
 const INIT_CONFIG: PostgresConfig = {
-    host: process.env.PGHOST || "postgres",
-    database: "lionweb_test",
+    host: PGHOST,
+    database: PGDATABASE,
     port: parseInt(process.env.PGPORT || "5432", 10),
-    user: process.env.PGUSER || "postgres",
+    user: PGUSER,
     password: process.env.PGPASSWORD || "lionweb"
 }
 


### PR DESCRIPTION
Attempt to fix the database tool. In particular:
- Update the name of the package containing the database tool in the package.json file
- Ensure the environment variables are taken into account

*NOTE: This is a draft pull request because when running the database create task it currently fails*

I cannot figure out why it fails. When executing this statement:

```
CREATE DATABASE foo2
    WITH
    OWNER = 'postgres'
    ENCODING = 'UTF8'
    LC_COLLATE = 'en_US.utf8'
    LC_CTYPE = 'en_US.utf8'
    LOCALE_PROVIDER = 'libc'
    TABLESPACE = pg_default
    CONNECTION LIMIT = -1
    IS_TEMPLATE = False;
```

The create script fails as the database `foo2` does not exist _which is the whole point: we are creating it!_