### PR TITLE
Adding possibility to configure a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ npm run lint
 
 ### How to start the repository server
 Ensure that Postgress is running.
-The repository server is started with `npm run dev` in  the `packages/core` folder:
+The repository server is started with `npm run dev` in  the `packages/server` folder:
 
 ```
-cd packages/core
+cd packages/server
 npm run dev
 ```
 
@@ -97,3 +97,10 @@ Tests for the core package
 In GitHub actions a Postgres server is started on a host named `postgres`.
 In your local development environment, this hostname is also being used.
 You need to ensure that this hostname points to the Postgres server. 
+
+## Authentication
+
+It is possible to specify a token to be expected by the server in each request (see [configuration.md](configuration.md)).
+This mechanism is intended to make possible to expose the LionWeb repository while providing a minimum level of 
+security. When the token is specified while launching the server, then each request to the server will be checked
+for the presence of the same token in the `Authorization` header.

--- a/configuration.md
+++ b/configuration.md
@@ -26,3 +26,5 @@ Environment variables can be used to configure the project:
 
 * **DB_VERBOSITY** (default `false`): Print queries and other information related to the DB
 * **REQUESTS_VERBOSITY** (default `true`): Print logs about the requested received
+* **EXPECTED_TOKEN** (default to _no token_): When a token is specified, it should be provided in all calls. 
+  Otherwise they would be rejected.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,6 @@
 import dotenv from "dotenv"
 import http from "http"
-import express, { Express } from "express"
+import express, {Express, NextFunction, Response, Request} from "express"
 import bodyParser from "body-parser"
 import cors from "cors"
 import { dbConnection, pgp } from "./DbConnection.js"
@@ -9,6 +9,7 @@ import { registerInspection } from "@lionweb/repository-inspection"
 import { registerBulkApi } from "@lionweb/repository-bulkapi"
 import { registerAdditionalApi } from "@lionweb/repository-additionalapi"
 import { registerLanguagesApi } from "@lionweb/repository-languages"
+import { HttpClientErrors } from "@lionweb/repository-common"
 
 dotenv.config()
 
@@ -27,6 +28,23 @@ app.use(
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(bodyParser.json({limit: process.env.BODY_LIMIT || '50mb'}))
 
+const expectedToken = process.env.EXPECTED_TOKEN
+
+function verifyToken(req: Request, res: Response, next: NextFunction) {
+    if (expectedToken != null) {
+        const providedToken = req.headers['authorization']
+        if (providedToken == null || typeof providedToken !== "string" || providedToken.trim() != expectedToken) {
+            return res.status(HttpClientErrors.Unauthorized).send("Invalid token or no token provided")
+        } else {
+            next();
+        }
+    } else {
+        next()
+    }
+}
+
+app.use(verifyToken)
+
 registerDBAdmin(app, dbConnection, pgp)
 registerBulkApi(app, dbConnection, pgp)
 registerInspection(app, dbConnection, pgp)
@@ -36,6 +54,13 @@ registerLanguagesApi(app, dbConnection, pgp)
 const httpServer = http.createServer(app)
 
 const serverPort = parseInt(process.env.NODE_PORT || "3005")
+
 httpServer.listen(serverPort, () => {
     console.log(`Server is running at port ${serverPort} =========================================================`)
+    if (expectedToken == null) {
+        console.log("WARNING! The server is not protected by a token. It can be accessed freely. " +
+            "If that is NOT your intention act accordingly.")
+    } else if (expectedToken.length < 24) {
+        console.log("WARNING! The used token is quite short. Consider using a token of 24 characters or more.")
+    }
 })


### PR DESCRIPTION
This PR implements the mechanism discussed in #38 .

When a token is not set, a warning message is displayed. A warning message is also indicated for short tokens.

This would permit the use of a publicly reachable model repository without having to implement a more complicated setup. While this is not an advanced solution, it introduces a little bit of security (a little should be better than zero) while still permitting other users to hide the Lionweb repository behind a proxy performing authentication for more advanced setups.

Fix #38 