### PR TITLE
Update to latest spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lionweb/repository",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lionweb/repository",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "workspaces": [
         "./packages/common",
@@ -6280,11 +6280,11 @@
     },
     "packages/additionalapi": {
       "name": "@lionweb/repository-additionalapi",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lionweb/repository-common": "0.1.0",
-        "@lionweb/repository-dbadmin": "0.1.0",
+        "@lionweb/repository-common": "0.1.1",
+        "@lionweb/repository-dbadmin": "0.1.1",
         "@lionweb/validation": "0.6.2",
         "@types/express": "4.17.21",
         "body-parser": "1.20.2",
@@ -6312,11 +6312,11 @@
     },
     "packages/bulkapi": {
       "name": "@lionweb/repository-bulkapi",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lionweb/repository-common": "0.1.0",
-        "@lionweb/repository-dbadmin": "0.1.0",
+        "@lionweb/repository-common": "0.1.1",
+        "@lionweb/repository-dbadmin": "0.1.1",
         "@lionweb/validation": "0.6.2",
         "@types/express": "4.17.21",
         "@types/source-map-support": "0.5.10",
@@ -6345,7 +6345,7 @@
     },
     "packages/common": {
       "name": "@lionweb/repository-common",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@lionweb/validation": "0.6.2",
@@ -6357,26 +6357,26 @@
     },
     "packages/dbadmin": {
       "name": "@lionweb/repository-dbadmin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lionweb/repository-common": "0.1.0"
+        "@lionweb/repository-common": "0.1.1"
       }
     },
     "packages/inspection": {
       "name": "@lionweb/repository-inspection",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lionweb/repository-dbadmin": "0.1.0"
+        "@lionweb/repository-dbadmin": "0.1.1"
       }
     },
     "packages/languages": {
       "name": "@lionweb/repository-languages",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lionweb/repository-dbadmin": "0.1.0",
+        "@lionweb/repository-dbadmin": "0.1.1",
         "@lionweb/validation": "0.6.2",
         "@types/express": "4.17.21",
         "body-parser": "1.20.2",
@@ -6404,15 +6404,15 @@
     },
     "packages/server": {
       "name": "@lionweb/repository-server",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lionweb/repository-additionalapi": "0.1.0",
-        "@lionweb/repository-bulkapi": "0.1.0",
-        "@lionweb/repository-common": "0.1.0",
-        "@lionweb/repository-dbadmin": "0.1.0",
-        "@lionweb/repository-inspection": "0.1.0",
-        "@lionweb/repository-languages": "0.1.0",
+        "@lionweb/repository-additionalapi": "0.1.1",
+        "@lionweb/repository-bulkapi": "0.1.1",
+        "@lionweb/repository-common": "0.1.1",
+        "@lionweb/repository-dbadmin": "0.1.1",
+        "@lionweb/repository-inspection": "0.1.1",
+        "@lionweb/repository-languages": "0.1.1",
         "@lionweb/validation": "0.6.2",
         "@types/express": "4.17.21",
         "body-parser": "1.20.2",
@@ -6440,7 +6440,7 @@
     },
     "packages/test": {
       "name": "@lionweb/repository-test",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@lionweb/validation": "0.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6074,6 +6074,18 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
@@ -6352,7 +6364,8 @@
         "@types/express": "4.17.21",
         "pg": "8.11.3",
         "pg-promise": "11.5.4",
-        "source-map-support": "0.5.21"
+        "source-map-support": "0.5.21",
+        "uuid": "9.0.1"
       }
     },
     "packages/dbadmin": {

--- a/packages/additionalapi/src/controllers/AdditionalApi.ts
+++ b/packages/additionalapi/src/controllers/AdditionalApi.ts
@@ -4,8 +4,7 @@ import {
     EMPTY_SUCCES_RESPONSE,
     getIntegerParam,
     HttpClientErrors,
-    HttpSuccessCodes,
-    isResponseMessage,
+    HttpSuccessCodes, isParameterError,
     lionwebResponse,
     logger
 } from "@lionweb/repository-common"
@@ -25,10 +24,10 @@ export class AdditionalApiImpl implements AdditionalApi {
     getNodeTree = async (request: Request, response: Response): Promise<void> => {
         const idList = request.body.ids
         const depthLimit = getIntegerParam(request, "depthLimit", Number.MAX_SAFE_INTEGER)
-        if (isResponseMessage(depthLimit)) {
+        if (isParameterError(depthLimit)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [depthLimit]
+                messages: [depthLimit.error]
             })
         } else {
             logger.dbLog("API.getNodeTree is " + idList)

--- a/packages/bulkapi/src/controllers/BulkApi.ts
+++ b/packages/bulkapi/src/controllers/BulkApi.ts
@@ -13,17 +13,17 @@ import {
     lionwebResponse,
     ResponseMessage,
     DeletePartitionsResponse,
-    StoreResponse, HttpClientErrors, HttpSuccessCodes
+    StoreResponse, HttpClientErrors, HttpSuccessCodes, isResponseMessage, getStringParam, getIntegerParam
 } from "@lionweb/repository-common"
 
 export interface BulkApi {
-    listPartitions: (req: Request, response: Response) => void
-    createPartitions: (req: Request, response: Response) => void
-    deletePartitions: (req: Request, response: Response) => void
+    listPartitions: (request: Request, response: Response) => void
+    createPartitions: (request: Request, response: Response) => void
+    deletePartitions: (request: Request, response: Response) => void
 
-    store: (req: Request, response: Response) => void
-    retrieve: (req: Request, response: Response) => void
-    ids: (req: Request, response: Response) => void
+    store: (request: Request, response: Response) => void
+    retrieve: (request: Request, response: Response) => void
+    ids: (request: Request, response: Response) => void
 }
 
 export class BulkApiImpl implements BulkApi {
@@ -32,76 +32,105 @@ export class BulkApiImpl implements BulkApi {
     }
     /**
      * Bulk API: Get all partitions (nodes without parent) from the repo
-     * @param req no `parameters` or `body`
+     * @param request no `parameters` or `body`
      * @param response The list of all partition nodes, without children or annotations
      */
-    listPartitions = async (req: Request, response: Response): Promise<void> => {
-        logger.requestLog(` * partitions request received, with body of ${req.headers["content-length"]} bytes`)
-        const result = await this.ctx.bulkApiWorker.bulkPartitions()
-        lionwebResponse<PartitionsResponse>(response, result.status, result.queryResult)
-    }
-
-    createPartitions = async (req: Request, response: Response): Promise<void> => {
-        logger.requestLog(` * createPartitions request received, with body of ${req.headers["content-length"]} bytes`)
-        const chunk: LionWebJsonChunk = req.body
-        const validator = new LionWebValidator(chunk, getLanguageRegistry())
-        validator.validateSyntax()
-        validator.validateReferences()
-        if (validator.validationResult.hasErrors()) {
-            lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
+    listPartitions = async (request: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * listPartitions request received, with body of ${request.headers["content-length"]} bytes`)
+        const clientId = getStringParam(request, "clientId")
+        if (isResponseMessage(clientId)) {
+            lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: validator.validationResult.issues.map(issue => ({kind: issue.issueType, message: issue.errorMsg()}))
+                messages: [clientId]
             })
         } else {
-            const issues: ResponseMessage[] = []
-            for (const node of chunk.nodes) {
-                if (node.parent !== null && node.parent !== undefined) {
-                    issues.push({ kind: "PartitionHasParent", message: `Node ${node} cannot be created as partition because it has a parent.`})
-                }
-                for (const containment of node.containments) {
-                    if (containment.children.length !== 0) {
-                        issues.push({ kind: "PartitionHasChildren", message: `Node ${node.id} cannot be created as a partition because it has children in containment ${containment.containment.key}` })
-                    }
-                }
-                if (node.annotations.length !== 0) {
-                    issues.push({ kind: "PartitionHasAnnotations", message: `Node ${node.id} cannot be created as a partition because it has annotations`} )
-                }
-            }
-            if (issues.length !== 0) {
-                lionwebResponse<CreatePartitionsResponse>(response, HttpClientErrors.PreconditionFailed, {
-                    success: false,
-                    messages: issues
-                })
-                return
-            }
-            if (chunk.nodes.length === 0) {
-                // do nothing, no new partitions
-                lionwebResponse<CreatePartitionsResponse>(response, HttpSuccessCodes.Ok, {
-                    success: true,
-                    messages: [{ kind: "EmptyChunk", message: "-- empty partitions list, no query"}]
-                })
-                return
-            }
-            const x = await this.ctx.bulkApiWorker.createPartitions(chunk)
-            lionwebResponse<CreatePartitionsResponse>(response, x.status, x.queryResult)
+            const result = await this.ctx.bulkApiWorker.bulkPartitions(clientId)
+            lionwebResponse<PartitionsResponse>(response, result.status, result.queryResult)
         }
     }
 
-    deletePartitions = async (req: Request, response: Response): Promise<void> => {
-        logger.requestLog(` * deletePartitions request received, with body of ${req.headers["content-length"]} bytes`)
-        const idList = req.body
-        const x = await this.ctx.bulkApiWorker.deletePartitions(idList)
-        lionwebResponse<DeletePartitionsResponse>(response, x.status, x.queryResult)
+    createPartitions = async (request: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * createPartitions request received, with body of ${request.headers["content-length"]} bytes`)
+        const clientId = getStringParam(request, "clientId")
+        const chunk: LionWebJsonChunk = request.body
+        if (isResponseMessage(clientId)) {
+            lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
+                success: false,
+                messages: [clientId]
+            })
+        } else {
+            const validator = new LionWebValidator(chunk, getLanguageRegistry())
+            validator.validateSyntax()
+            validator.validateReferences()
+            if (validator.validationResult.hasErrors()) {
+                lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
+                    success: false,
+                    messages: validator.validationResult.issues.map(issue => ({ kind: issue.issueType, message: issue.errorMsg() }))
+                })
+            } else {
+                const issues: ResponseMessage[] = []
+                for (const node of chunk.nodes) {
+                    if (node.parent !== null && node.parent !== undefined) {
+                        issues.push({ kind: "PartitionHasParent", message: `Node ${node} cannot be created as partition because it has a parent.` })
+                    }
+                    for (const containment of node.containments) {
+                        if (containment.children.length !== 0) {
+                            issues.push({
+                                kind: "PartitionHasChildren",
+                                message: `Node ${node.id} cannot be created as a partition because it has children in containment ${containment.containment.key}`
+                            })
+                        }
+                    }
+                    if (node.annotations.length !== 0) {
+                        issues.push({ kind: "PartitionHasAnnotations", message: `Node ${node.id} cannot be created as a partition because it has annotations` })
+                    }
+                }
+                if (issues.length !== 0) {
+                    lionwebResponse<CreatePartitionsResponse>(response, HttpClientErrors.PreconditionFailed, {
+                        success: false,
+                        messages: issues
+                    })
+                    return
+                }
+                if (chunk.nodes.length === 0) {
+                    // do nothing, no new partitions
+                    lionwebResponse<CreatePartitionsResponse>(response, HttpSuccessCodes.Ok, {
+                        success: true,
+                        messages: [{ kind: "EmptyChunk", message: "-- empty partitions list, no query" }]
+                    })
+                    return
+                }
+                const x = await this.ctx.bulkApiWorker.createPartitions(clientId, chunk)
+                lionwebResponse<CreatePartitionsResponse>(response, x.status, x.queryResult)
+            }
+        }
+    }
+
+    deletePartitions = async (request: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * deletePartitions request received, with body of ${request.headers["content-length"]} bytes`)
+        const clientId = getStringParam(request, "clientId")
+        const idList = request.body
+        if (isResponseMessage(clientId)) {
+            logger.requestLog("STORE CLIENT ID ERROR: clientId incorrect: " + JSON.stringify(clientId))
+            lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
+                success: false,
+                messages: [clientId]
+            })
+        } else {
+            const x = await this.ctx.bulkApiWorker.deletePartitions(clientId, idList)
+            lionwebResponse<DeletePartitionsResponse>(response, x.status, x.queryResult)
+        }
     }
 
     /**
      * Bulk API: Store all nodes in the request
-     * @param req `body` contains the array of all nodes to store
+     * @param request `body` contains the array of all nodes to store
      * @param response `ok`  if everything is correct
      */
-    store = async (req: Request, response: Response): Promise<void> => {
-        logger.requestLog(` * store request received, with body of ${req.headers["content-length"]} bytes`)
-        const chunk: LionWebJsonChunk = req.body
+    store = async (request: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * store request received, with body of ${request.headers["content-length"]} bytes`)
+        const clientId = getStringParam(request, "clientId")
+        const chunk: LionWebJsonChunk = request.body
         const validator = new LionWebValidator(chunk, getLanguageRegistry())
         validator.validateSyntax()
         validator.validateReferences()
@@ -111,28 +140,39 @@ export class BulkApiImpl implements BulkApi {
                 success: false,
                 messages: validator.validationResult.issues.map(issue => ({ kind: issue.issueType, message: issue.errorMsg() }))
             })
+        } else if (isResponseMessage(clientId)) {
+            logger.requestLog("STORE CLIENT ID ERROR: clientId incorrect: " + JSON.stringify(clientId))
+            lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
+                success: false,
+                messages: [clientId]
+            })
         } else {
-            const result = await this.ctx.bulkApiWorker.bulkStore(chunk)
+            const result = await this.ctx.bulkApiWorker.bulkStore(clientId, chunk)
             lionwebResponse<StoreResponse>(response, result.status, result.queryResult)
         }
     }
 
     /**
      * Bulk API: Retrieve a set of nodes including its parts to a given level
-     * @param req `body.ids` contains the list of nodes to be found.
+     * @param request `body.ids` contains the list of nodes to be found.
      *            parameter `depthLimit` contains the depth to which the parts are also found.
      * @param response
      */
-    retrieve = async (req: Request, response: Response): Promise<void> => {
-        logger.requestLog(` * retrieve request received, with body of ${req.headers["content-length"]} bytes`)
-        const depthParam = req.query["depthLimit"]
-        const depthLimit = (typeof depthParam === "string") ? Number.parseInt(depthParam) : Number.MAX_SAFE_INTEGER
-        const idList = req.body.ids
-        logger.requestLog("Api.getNodes: " + JSON.stringify(req.body) + " depth " + depthLimit)
-        if (isNaN(depthLimit)) {
+    retrieve = async (request: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * retrieve request received, with body of ${request.headers["content-length"]} bytes`)
+        const clientId = getStringParam(request, "clientId")
+        const depthLimit = getIntegerParam(request, "depthLimit", Number.MAX_SAFE_INTEGER)
+        const idList = request.body.ids
+        logger.requestLog("Api.getNodes: " + JSON.stringify(request.body) + " depth " + depthLimit + " clientId: " + clientId)
+        if (isResponseMessage(depthLimit)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [{ kind: "DepthLimitIncorrect", message: `parameter 'depthLimit' is not a number, but is '${req.query["depthLimit"]}' ` }]
+                messages: [depthLimit]
+            })
+        } else if (isResponseMessage(clientId)) {
+            lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
+                success: false,
+                messages: [clientId]
             })
         } else if (!Array.isArray(idList)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
@@ -140,18 +180,18 @@ export class BulkApiImpl implements BulkApi {
                 messages: [{ kind: "IdsIncorrect", message: `parameter 'ids' is not an array` }]
             })
         } else {
-            const result = await this.ctx.bulkApiWorker.bulkRetrieve(idList, depthLimit)
+            const result = await this.ctx.bulkApiWorker.bulkRetrieve(clientId, idList, depthLimit)
             lionwebResponse(response, result.status, result.queryResult)
         }
     }
 
     /**
      * TODO Implement this properly.
-     * @param req
+     * @param request
      * @param response
      */
-    ids = async (req: Request, response: Response): Promise<void> => {
-        logger.requestLog(` * ids request received, with body of ${req.headers["content-length"]} bytes`)
+    ids = async (request: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * ids request received, with body of ${request.headers["content-length"]} bytes`)
         lionwebResponse(response, HttpSuccessCodes.Ok, {
             success: true,
             messages: [],
@@ -160,3 +200,4 @@ export class BulkApiImpl implements BulkApi {
     }
 
 }
+

--- a/packages/bulkapi/src/controllers/BulkApi.ts
+++ b/packages/bulkapi/src/controllers/BulkApi.ts
@@ -17,12 +17,13 @@ import {
 } from "@lionweb/repository-common"
 
 export interface BulkApi {
-    partitions: (req: Request, response: Response) => void
-    
+    listPartitions: (req: Request, response: Response) => void
     createPartitions: (req: Request, response: Response) => void
     deletePartitions: (req: Request, response: Response) => void
+
     store: (req: Request, response: Response) => void
     retrieve: (req: Request, response: Response) => void
+    ids: (req: Request, response: Response) => void
 }
 
 export class BulkApiImpl implements BulkApi {
@@ -34,7 +35,7 @@ export class BulkApiImpl implements BulkApi {
      * @param req no `parameters` or `body`
      * @param response The list of all partition nodes, without children or annotations
      */
-    partitions = async (req: Request, response: Response): Promise<void> => {
+    listPartitions = async (req: Request, response: Response): Promise<void> => {
         logger.requestLog(` * partitions request received, with body of ${req.headers["content-length"]} bytes`)
         const result = await this.ctx.bulkApiWorker.bulkPartitions()
         lionwebResponse<PartitionsResponse>(response, result.status, result.queryResult)
@@ -124,7 +125,6 @@ export class BulkApiImpl implements BulkApi {
      */
     retrieve = async (req: Request, response: Response): Promise<void> => {
         logger.requestLog(` * retrieve request received, with body of ${req.headers["content-length"]} bytes`)
-        const mode = req.query["mode"] as string
         const depthParam = req.query["depthLimit"]
         const depthLimit = (typeof depthParam === "string") ? Number.parseInt(depthParam) : Number.MAX_SAFE_INTEGER
         const idList = req.body.ids
@@ -140,8 +140,23 @@ export class BulkApiImpl implements BulkApi {
                 messages: [{ kind: "IdsIncorrect", message: `parameter 'ids' is not an array` }]
             })
         } else {
-            const result = await this.ctx.bulkApiWorker.bulkRetrieve(idList, mode, depthLimit)
+            const result = await this.ctx.bulkApiWorker.bulkRetrieve(idList, depthLimit)
             lionwebResponse(response, result.status, result.queryResult)
         }
     }
+
+    /**
+     * TODO Implement this properly.
+     * @param req
+     * @param response
+     */
+    ids = async (req: Request, response: Response): Promise<void> => {
+        logger.requestLog(` * ids request received, with body of ${req.headers["content-length"]} bytes`)
+        lionwebResponse(response, HttpSuccessCodes.Ok, {
+            success: true,
+            messages: [],
+            ids: ["1", "2", "3"]
+        })        
+    }
+
 }

--- a/packages/bulkapi/src/controllers/BulkApi.ts
+++ b/packages/bulkapi/src/controllers/BulkApi.ts
@@ -192,11 +192,22 @@ export class BulkApiImpl implements BulkApi {
      */
     ids = async (request: Request, response: Response): Promise<void> => {
         logger.requestLog(` * ids request received, with body of ${request.headers["content-length"]} bytes`)
-        lionwebResponse(response, HttpSuccessCodes.Ok, {
-            success: true,
-            messages: [],
-            ids: ["1", "2", "3"]
-        })        
+        const clientId = getStringParam(request, "clientId")
+        const count = getIntegerParam(request, "count", Number.MAX_SAFE_INTEGER)
+        if (isResponseMessage(count)) {
+            lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
+                success: false,
+                messages: [count]
+            })
+        } else if (isResponseMessage(clientId)) {
+            lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
+                success: false,
+                messages: [clientId]
+            })
+        } else {
+            const result = await this.ctx.bulkApiWorker.ids(clientId, count)
+            lionwebResponse(response, result.status, result.queryResult)
+        }
     }
 
 }

--- a/packages/bulkapi/src/controllers/BulkApi.ts
+++ b/packages/bulkapi/src/controllers/BulkApi.ts
@@ -13,7 +13,7 @@ import {
     lionwebResponse,
     ResponseMessage,
     DeletePartitionsResponse,
-    StoreResponse, HttpClientErrors, HttpSuccessCodes, isResponseMessage, getStringParam, getIntegerParam
+    StoreResponse, HttpClientErrors, HttpSuccessCodes, getStringParam, getIntegerParam, isParameterError
 } from "@lionweb/repository-common"
 
 export interface BulkApi {
@@ -38,10 +38,10 @@ export class BulkApiImpl implements BulkApi {
     listPartitions = async (request: Request, response: Response): Promise<void> => {
         logger.requestLog(` * listPartitions request received, with body of ${request.headers["content-length"]} bytes`)
         const clientId = getStringParam(request, "clientId")
-        if (isResponseMessage(clientId)) {
+        if (isParameterError(clientId)) {
             lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [clientId]
+                messages: [clientId.error]
             })
         } else {
             const result = await this.ctx.bulkApiWorker.bulkPartitions(clientId)
@@ -53,10 +53,10 @@ export class BulkApiImpl implements BulkApi {
         logger.requestLog(` * createPartitions request received, with body of ${request.headers["content-length"]} bytes`)
         const clientId = getStringParam(request, "clientId")
         const chunk: LionWebJsonChunk = request.body
-        if (isResponseMessage(clientId)) {
+        if (isParameterError(clientId)) {
             lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [clientId]
+                messages: [clientId.error]
             })
         } else {
             const validator = new LionWebValidator(chunk, getLanguageRegistry())
@@ -110,11 +110,11 @@ export class BulkApiImpl implements BulkApi {
         logger.requestLog(` * deletePartitions request received, with body of ${request.headers["content-length"]} bytes`)
         const clientId = getStringParam(request, "clientId")
         const idList = request.body
-        if (isResponseMessage(clientId)) {
+        if (isParameterError(clientId)) {
             logger.requestLog("STORE CLIENT ID ERROR: clientId incorrect: " + JSON.stringify(clientId))
             lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [clientId]
+                messages: [clientId.error]
             })
         } else {
             const x = await this.ctx.bulkApiWorker.deletePartitions(clientId, idList)
@@ -140,11 +140,11 @@ export class BulkApiImpl implements BulkApi {
                 success: false,
                 messages: validator.validationResult.issues.map(issue => ({ kind: issue.issueType, message: issue.errorMsg() }))
             })
-        } else if (isResponseMessage(clientId)) {
+        } else if (isParameterError(clientId)) {
             logger.requestLog("STORE CLIENT ID ERROR: clientId incorrect: " + JSON.stringify(clientId))
             lionwebResponse<StoreResponse>(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [clientId]
+                messages: [clientId.error]
             })
         } else {
             const result = await this.ctx.bulkApiWorker.bulkStore(clientId, chunk)
@@ -164,15 +164,15 @@ export class BulkApiImpl implements BulkApi {
         const depthLimit = getIntegerParam(request, "depthLimit", Number.MAX_SAFE_INTEGER)
         const idList = request.body.ids
         logger.requestLog("Api.getNodes: " + JSON.stringify(request.body) + " depth " + depthLimit + " clientId: " + clientId)
-        if (isResponseMessage(depthLimit)) {
+        if (isParameterError(depthLimit)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [depthLimit]
+                messages: [depthLimit.error]
             })
-        } else if (isResponseMessage(clientId)) {
+        } else if (isParameterError(clientId)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [clientId]
+                messages: [clientId.error]
             })
         } else if (!Array.isArray(idList)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
@@ -194,15 +194,15 @@ export class BulkApiImpl implements BulkApi {
         logger.requestLog(` * ids request received, with body of ${request.headers["content-length"]} bytes`)
         const clientId = getStringParam(request, "clientId")
         const count = getIntegerParam(request, "count", Number.MAX_SAFE_INTEGER)
-        if (isResponseMessage(count)) {
+        if (isParameterError(count)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [count]
+                messages: [count.error]
             })
-        } else if (isResponseMessage(clientId)) {
+        } else if (isParameterError(clientId)) {
             lionwebResponse(response, HttpClientErrors.PreconditionFailed, {
                 success: false,
-                messages: [clientId]
+                messages: [clientId.error]
             })
         } else {
             const result = await this.ctx.bulkApiWorker.ids(clientId, count)

--- a/packages/bulkapi/src/controllers/BulkApiWorker.ts
+++ b/packages/bulkapi/src/controllers/BulkApiWorker.ts
@@ -81,7 +81,7 @@ export class BulkApiWorker {
      * @param mode
      * @param depthLimit
      */
-    bulkRetrieve = async (nodeIdList: string[], mode: string, depthLimit: number): Promise<QueryReturnType<RetrieveResponse>> => {
+    bulkRetrieve = async (nodeIdList: string[], depthLimit: number): Promise<QueryReturnType<RetrieveResponse>> => {
         if (nodeIdList.length === 0) {
             return {
                 status: HttpSuccessCodes.Ok,

--- a/packages/bulkapi/src/controllers/BulkApiWorker.ts
+++ b/packages/bulkapi/src/controllers/BulkApiWorker.ts
@@ -19,14 +19,15 @@ export class BulkApiWorker {
         this.context = context
     }
 
-    async bulkPartitions(): Promise<QueryReturnType<PartitionsResponse>> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async bulkPartitions(clientId: string): Promise<QueryReturnType<PartitionsResponse>> {
         return await this.context.queries.getPartitions()
     }
 
     /**
      * @param chunk A LionWeb chunk containing all nodes that are to be created as partitions.
      */
-    createPartitions = async (chunk: LionWebJsonChunk): Promise<QueryReturnType<CreatePartitionsResponse>> => {
+    createPartitions = async (clientId: string, chunk: LionWebJsonChunk): Promise<QueryReturnType<CreatePartitionsResponse>> => {
         logger.requestLog("BulkApiWorker.createPartitions")
         const existingNodes = await this.context.queries.getNodesFromIdList(chunk.nodes.map(n => n.id))
         if (existingNodes.length > 0) {
@@ -49,7 +50,7 @@ export class BulkApiWorker {
      * Delete all partitions 
      * @param idList The list of node id's of partition nodes that are to be removed.
      */
-    deletePartitions = async(idList: string[]): Promise<QueryReturnType<DeletePartitionsResponse>> => {
+    deletePartitions = async(clientId: string, idList: string[]): Promise<QueryReturnType<DeletePartitionsResponse>> => {
         const partitions = await this.context.queries.getNodesFromIdList(idList)
         const issues: ResponseMessage[] = []
         partitions.forEach(part => {
@@ -71,17 +72,16 @@ export class BulkApiWorker {
         return { status: HttpSuccessCodes.Ok, query: "", queryResult: EMPTY_SUCCES_RESPONSE }
     }
 
-    bulkStore = async (chunk: LionWebJsonChunk): Promise<QueryReturnType<StoreResponse>> => {
-        return await this.context.queries.store(chunk)
+    bulkStore = async (clientId: string, chunk: LionWebJsonChunk): Promise<QueryReturnType<StoreResponse>> => {
+        return await this.context.queries.store(clientId, chunk)
     }
 
     /**
      * This implementation uses Postgres for querying
      * @param nodeIdList
-     * @param mode
      * @param depthLimit
      */
-    bulkRetrieve = async (nodeIdList: string[], depthLimit: number): Promise<QueryReturnType<RetrieveResponse>> => {
+    bulkRetrieve = async (clientId: string, nodeIdList: string[], depthLimit: number): Promise<QueryReturnType<RetrieveResponse>> => {
         if (nodeIdList.length === 0) {
             return {
                 status: HttpSuccessCodes.Ok,

--- a/packages/bulkapi/src/database/LionWebQueries.ts
+++ b/packages/bulkapi/src/database/LionWebQueries.ts
@@ -130,7 +130,7 @@ export class LionWebQueries {
         const tbsContainedChildIds = this.getContainedIds(toBeStoredChunk.nodes)
         const tbsNodeAndChildIds = [...tbsNodeIds, ...tbsContainedChildIds.filter(cid => !tbsNodeIds.includes(cid))]
         // Retrieve nodes for all id's that exist
-        const databaseChunk = await this.context.bulkApiWorker.bulkRetrieve(tbsNodeAndChildIds, "", 0)
+        const databaseChunk = await this.context.bulkApiWorker.bulkRetrieve(tbsNodeAndChildIds, 0)
         const databaseChunkWrapper = new LionWebJsonChunkWrapper(databaseChunk.queryResult.chunk)
         logger.dbLog("DBChunk " + JSON.stringify(databaseChunkWrapper.jsonChunk))
         
@@ -210,12 +210,10 @@ export class LionWebQueries {
         // implicit child remove, find all parents
         const implicitlyRemovedChildNodes = await this.context.bulkApiWorker.bulkRetrieve(
             addedAndNotRemovedChildren.map(ch => ch.childId),
-            "",
             0
         )
         const parentsOfImplicitlyRemovedChildNodes = await this.context.bulkApiWorker.bulkRetrieve(
             implicitlyRemovedChildNodes.queryResult.chunk.nodes.map(node => node.parent),
-            "",
             0
         )
         // Now all changes are turned into queries.

--- a/packages/bulkapi/src/database/LionWebQueries.ts
+++ b/packages/bulkapi/src/database/LionWebQueries.ts
@@ -115,7 +115,7 @@ export class LionWebQueries {
      *
      * @param toBeStoredChunk
      */
-    store = async (toBeStoredChunk: LionWebJsonChunk): Promise<QueryReturnType<StoreResponse>> => {
+    store = async (clientId: string, toBeStoredChunk: LionWebJsonChunk): Promise<QueryReturnType<StoreResponse>> => {
         logger.dbLog("LionWebQueries.store")
         if (toBeStoredChunk === null || toBeStoredChunk === undefined) {
             return {
@@ -130,7 +130,7 @@ export class LionWebQueries {
         const tbsContainedChildIds = this.getContainedIds(toBeStoredChunk.nodes)
         const tbsNodeAndChildIds = [...tbsNodeIds, ...tbsContainedChildIds.filter(cid => !tbsNodeIds.includes(cid))]
         // Retrieve nodes for all id's that exist
-        const databaseChunk = await this.context.bulkApiWorker.bulkRetrieve(tbsNodeAndChildIds, 0)
+        const databaseChunk = await this.context.bulkApiWorker.bulkRetrieve(clientId, tbsNodeAndChildIds, 0)
         const databaseChunkWrapper = new LionWebJsonChunkWrapper(databaseChunk.queryResult.chunk)
         logger.dbLog("DBChunk " + JSON.stringify(databaseChunkWrapper.jsonChunk))
         
@@ -209,10 +209,12 @@ export class LionWebQueries {
 
         // implicit child remove, find all parents
         const implicitlyRemovedChildNodes = await this.context.bulkApiWorker.bulkRetrieve(
+            clientId,
             addedAndNotRemovedChildren.map(ch => ch.childId),
             0
         )
         const parentsOfImplicitlyRemovedChildNodes = await this.context.bulkApiWorker.bulkRetrieve(
+            clientId,
             implicitlyRemovedChildNodes.queryResult.chunk.nodes.map(node => node.parent),
             0
         )

--- a/packages/bulkapi/src/database/QueryMaker.ts
+++ b/packages/bulkapi/src/database/QueryMaker.ts
@@ -8,7 +8,7 @@ import {
     ORPHANS_REFERENCES_TABLE,
     PROPERTIES_TABLE,
     REFERENCES_TABLE,
-    logger, TableHelpers
+    logger, TableHelpers, RESERVED_IDS_TABLE
 } from "@lionweb/repository-common"
 import {
     ChildAdded,
@@ -300,6 +300,11 @@ export class QueryMaker {
         return query
     }
 
+    // public dbCheckReservedIds(clientId: string, tbsNodesToCreate: LionWebJsonNode[]): string[] {
+    //     logger.dbLog("Queries check reserved ids for " + clientId + " with nodes: " + tbsNodesToCreate.map(n => n.id))
+    //    
+    // }
+
     /**
      * Insert _tbsNodesToCreate in the lionweb_nodes table
      * These nodes are all new nodes.
@@ -359,6 +364,15 @@ export class QueryMaker {
     public makeSelectNodesIdsWithoutParent(): string {
         return `SELECT id FROM ${NODES_TABLE} WHERE parent is null`
     }
-    
+
+    public findReservedNodesFromIdList(clientId: string, nodeIdList: string[]): string {
+        const sqlArray = sqlArrayFromNodeIdArray(nodeIdList)
+        return `-- Retrieve node tree
+            SELECT node_id, client_id
+            FROM ${RESERVED_IDS_TABLE}
+            WHERE node_id IN ${sqlArray}  AND client_id != '${clientId}'   
+    `
+    }
+
     public async deleteNodesFromIdList(idList: string[]){ return idList }
 }

--- a/packages/bulkapi/src/database/QueryMaker.ts
+++ b/packages/bulkapi/src/database/QueryMaker.ts
@@ -397,6 +397,4 @@ export class QueryMaker {
 
         return ""
     }
-
-    public async deleteNodesFromIdList(idList: string[]){ return idList }
 }

--- a/packages/bulkapi/src/main.ts
+++ b/packages/bulkapi/src/main.ts
@@ -48,6 +48,7 @@ export function registerBulkApi(app: Express, dbConnection: pgPromise.IDatabase<
     app.post("/bulk/createPartitions", runWithTry(context.bulkApi.createPartitions))
     app.post("/bulk/deletePartitions", runWithTry(context.bulkApi.deletePartitions))
     app.get("/bulk/listPartitions", runWithTry(context.bulkApi.listPartitions))
+    app.post("/bulk/ids", runWithTry(context.bulkApi.ids))
     app.post("/bulk/store", runWithTry(context.bulkApi.store))
     app.post("/bulk/retrieve", runWithTry(context.bulkApi.retrieve))
 }

--- a/packages/bulkapi/src/main.ts
+++ b/packages/bulkapi/src/main.ts
@@ -47,7 +47,7 @@ export function registerBulkApi(app: Express, dbConnection: pgPromise.IDatabase<
     // Add routes to application
     app.post("/bulk/createPartitions", runWithTry(context.bulkApi.createPartitions))
     app.post("/bulk/deletePartitions", runWithTry(context.bulkApi.deletePartitions))
-    app.get("/bulk/partitions", runWithTry(context.bulkApi.partitions))
+    app.get("/bulk/listPartitions", runWithTry(context.bulkApi.listPartitions))
     app.post("/bulk/store", runWithTry(context.bulkApi.store))
     app.post("/bulk/retrieve", runWithTry(context.bulkApi.retrieve))
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,6 +25,7 @@
     "@types/express": "4.17.21",
     "pg": "8.11.3",
     "pg-promise": "11.5.4",
-    "source-map-support": "0.5.21"
+    "source-map-support": "0.5.21",
+    "uuid": "9.0.1"
   }
 }

--- a/packages/common/src/apiutil/LionwebResponse.ts
+++ b/packages/common/src/apiutil/LionwebResponse.ts
@@ -25,6 +25,10 @@ export type ResponseMessage = {
     data?  : Record<string, string>
 }
 
+/**
+ * Checks whether the _object_ is a ResponseMessage
+ * @param object
+ */
 export function isResponseMessage(object: unknown): object is ResponseMessage {
     return object["kind"] !== undefined &&
         typeof object["kind"] === "string"

--- a/packages/common/src/apiutil/LionwebResponse.ts
+++ b/packages/common/src/apiutil/LionwebResponse.ts
@@ -54,6 +54,10 @@ export interface CreatePartitionsResponse extends LionwebResponse {
 export interface DeletePartitionsResponse extends LionwebResponse {
 }
 
+export interface IdsResponse extends LionwebResponse {
+    ids: string[]
+}
+
 export function lionwebResponse<T extends LionwebResponse>(response: Response, status: number, body: T): void {
     response.status(status)
     response.send(body)

--- a/packages/common/src/apiutil/LionwebResponse.ts
+++ b/packages/common/src/apiutil/LionwebResponse.ts
@@ -25,6 +25,13 @@ export type ResponseMessage = {
     data?  : Record<string, string>
 }
 
+export function isResponseMessage(object: unknown): object is ResponseMessage {
+    return object["kind"] !== undefined &&
+        typeof object["kind"] === "string"
+        object["message"] !== undefined &&
+        typeof object["message"] === "string"
+}
+
 export interface LionwebResponse {
     success: boolean
     messages: ResponseMessage[]

--- a/packages/common/src/apiutil/functions.ts
+++ b/packages/common/src/apiutil/functions.ts
@@ -2,22 +2,72 @@ import { HttpServerErrors } from "./httpcodes.js";
 import { collectUsedLanguages } from "./UsedLanguages.js";
 import { LionWebJsonChunk, LionWebJsonNode } from "@lionweb/validation";
 import { Request, Response } from "express"
-import { lionwebResponse } from "./LionwebResponse.js";
+import { lionwebResponse, ResponseMessage } from "./LionwebResponse.js";
+
+export function toFirstUpper(text: string): string {
+    return text[0].toUpperCase().concat(text.substring(1));
+}
+
+/**
+ * Get the query parameter named _paramName_ as a string value
+ * @param request   The request object containing the query
+ * @param paramName The name of the parameter.
+ * @returns The value of the query parameter if this is avalable and of type string, 
+ * Otherwise a ResponseMessage containing an error.
+ */
+export function getStringParam(request: Request, paramName: string): string | ResponseMessage {
+    const result = request.query[paramName];
+    if (typeof result === "string") {
+        return result as string
+    } else {
+        return {
+            kind: `${toFirstUpper(paramName)}Incorrect`,
+            message: `Parameter ${paramName} must be a string`
+        }
+    }
+}
+
+/**
+ * Get the query parameter named _paramName_ as an integer value
+ * @param request   The request object containing the query
+ * @param paramName The name of the parameter.
+ * @param defaultValue The default value in case the parameter is missing.
+ * @returns The value of the query parameter if this is avalable and represents an integer,
+ * the _defaultValue_ if the parameters is missing, and 
+ * otherwise a ResponseMessage containing an error.
+ */
+export function getIntegerParam(request: Request, paramName: string, defaultValue: number): number | ResponseMessage {
+    const result = request.query[paramName];
+    if (typeof result === "string") {
+        const value = Number.parseInt(result)
+        if (isNaN(value)) {
+            return {
+                kind: `${toFirstUpper(paramName)}Incorrect`,
+                message: `Parameter ${paramName} must be an integer, but it is ${result}`
+            }
+        } else {
+            return value
+        }
+    } else {
+        // In case of undefined return the default value
+        return defaultValue
+    }
+}
 
 /**
  * Catch-all wrapper function to handle exceptions for any api call
  * @param func
  */
-export function runWithTry( func: (req: Request, response: Response) => void): (req: Request, response: Response) => void {
-    return async function(req: Request, response: Response): Promise<void> {
+export function runWithTry( func: (request: Request, response: Response) => void): (request: Request, response: Response) => void {
+    return async function(request: Request, response: Response): Promise<void> {
         try {
-            await func(req, response)
+            await func(request, response)
         } catch(e) {
             const error = asError(e)
-            console.log(`Exception while serving request for ${req.url}: ${error.message}`)
+            console.log(`Exception while serving request for ${request.url}: ${error.message}`)
             lionwebResponse(response, HttpServerErrors.InternalServerError, {
                 success: false,
-                messages: [{ kind: error.name, message: `Exception while serving request for ${req.url}: ${error.message}` }]
+                messages: [{ kind: error.name, message: `Exception while serving request for ${request.url}: ${error.message}` }]
             })
         }
     }

--- a/packages/common/src/apiutil/functions.ts
+++ b/packages/common/src/apiutil/functions.ts
@@ -1,22 +1,23 @@
-import { HttpServerErrors } from "./httpcodes.js";
-import { collectUsedLanguages } from "./UsedLanguages.js";
-import { LionWebJsonChunk, LionWebJsonNode } from "@lionweb/validation";
+import { HttpServerErrors } from "./httpcodes.js"
+import { collectUsedLanguages } from "./UsedLanguages.js"
+import { LionWebJsonChunk, LionWebJsonNode } from "@lionweb/validation"
 import { Request, Response } from "express"
-import { lionwebResponse, ResponseMessage } from "./LionwebResponse.js";
+import { lionwebResponse, ResponseMessage } from "./LionwebResponse.js"
+import { v4 as uuidv4 } from "uuid"
 
 export function toFirstUpper(text: string): string {
-    return text[0].toUpperCase().concat(text.substring(1));
+    return text[0].toUpperCase().concat(text.substring(1))
 }
 
 /**
  * Get the query parameter named _paramName_ as a string value
  * @param request   The request object containing the query
  * @param paramName The name of the parameter.
- * @returns The value of the query parameter if this is avalable and of type string, 
+ * @returns The value of the query parameter if this is avalable and of type string,
  * Otherwise a ResponseMessage containing an error.
  */
 export function getStringParam(request: Request, paramName: string): string | ResponseMessage {
-    const result = request.query[paramName];
+    const result = request.query[paramName]
     if (typeof result === "string") {
         return result as string
     } else {
@@ -33,11 +34,11 @@ export function getStringParam(request: Request, paramName: string): string | Re
  * @param paramName The name of the parameter.
  * @param defaultValue The default value in case the parameter is missing.
  * @returns The value of the query parameter if this is avalable and represents an integer,
- * the _defaultValue_ if the parameters is missing, and 
+ * the _defaultValue_ if the parameters is missing, and
  * otherwise a ResponseMessage containing an error.
  */
 export function getIntegerParam(request: Request, paramName: string, defaultValue: number): number | ResponseMessage {
-    const result = request.query[paramName];
+    const result = request.query[paramName]
     if (typeof result === "string") {
         const value = Number.parseInt(result)
         if (isNaN(value)) {
@@ -58,11 +59,11 @@ export function getIntegerParam(request: Request, paramName: string, defaultValu
  * Catch-all wrapper function to handle exceptions for any api call
  * @param func
  */
-export function runWithTry( func: (request: Request, response: Response) => void): (request: Request, response: Response) => void {
-    return async function(request: Request, response: Response): Promise<void> {
+export function runWithTry(func: (request: Request, response: Response) => void): (request: Request, response: Response) => void {
+    return async function (request: Request, response: Response): Promise<void> {
         try {
             await func(request, response)
-        } catch(e) {
+        } catch (e) {
             const error = asError(e)
             console.log(`Exception while serving request for ${request.url}: ${error.message}`)
             lionwebResponse(response, HttpServerErrors.InternalServerError, {
@@ -71,6 +72,13 @@ export function runWithTry( func: (request: Request, response: Response) => void
             })
         }
     }
+}
+
+/**
+ * Get new node id
+ */
+export function createId(clientId: string): string {
+    return clientId + "-" + uuidv4()
 }
 
 /**

--- a/packages/common/src/database/TableDefinitions.ts
+++ b/packages/common/src/database/TableDefinitions.ts
@@ -3,7 +3,7 @@
  */
 import pgPromise from "pg-promise";
 import pg from "pg-promise/typescript/pg-subset.js";
-import { CONTAINMENTS_TABLE, NODES_TABLE, PROPERTIES_TABLE, REFERENCES_TABLE } from "./TableNames.js"
+import { CONTAINMENTS_TABLE, NODES_TABLE, PROPERTIES_TABLE, REFERENCES_TABLE, RESERVED_IDS_TABLE } from "./TableNames.js"
 
 // NOTE: '?' at front of column name means that this column will not be updated by an UPDATE
 
@@ -12,6 +12,7 @@ export class TableDefinitions {
     CONTAINMENTS_COLUMN_SET: pgPromise.ColumnSet
     PROPERTIES_COLUMN_SET: pgPromise.ColumnSet
     REFERENCES_COLUMN_SET: pgPromise.ColumnSet
+    RESERVED_IDS_COLUMN_SET: pgPromise.ColumnSet
     
     constructor(private pgp: pgPromise.IMain<object, pg.IClient>) {
         this.pgp = pgp
@@ -56,6 +57,14 @@ export class TableDefinitions {
                 "?node_id"      // Don't update this column
             ],
             { table: REFERENCES_TABLE }
+        )
+        // prettier-ignore
+        this.RESERVED_IDS_COLUMN_SET = new this.pgp.helpers.ColumnSet(
+            [
+                "node_id",      // The reserved node id
+                "client_id"     // The client for which the node id has been reserved
+            ],
+            { table: RESERVED_IDS_TABLE }
         )
     }
 }

--- a/packages/common/src/database/TableNames.ts
+++ b/packages/common/src/database/TableNames.ts
@@ -2,6 +2,7 @@ export const NODES_TABLE: string = "lionweb_nodes"
 export const CONTAINMENTS_TABLE: string = "lionweb_containments"
 export const REFERENCES_TABLE: string = "lionweb_references"
 export const PROPERTIES_TABLE: string = "lionweb_properties"
+export const RESERVED_IDS_TABLE: string = "lionweb_reserved_ids"
 
 export const ORPHANS_NODES_TABLE: string = "lionweb_nodes_orphans"
 export const ORPHANS_CONTAINMENTS_TABLE: string = "lionweb_containments_orphans"

--- a/packages/common/src/database/TableTypes.ts
+++ b/packages/common/src/database/TableTypes.ts
@@ -1,0 +1,15 @@
+// Types for table query results
+
+export type ReservedIdRecord = {
+    node_id: string,
+    client_id: string
+}
+
+export type NodeRecord = {
+    id,                   // The node id // Don't update this column
+    classifier_language,  // The classifier of the node
+    classifier_version,   // The classifier of the node
+    classifier_key,       // The classifier of the node
+    annotations,          // The annotation(id)s
+    parent
+}

--- a/packages/common/src/database/index.ts
+++ b/packages/common/src/database/index.ts
@@ -1,2 +1,3 @@
 export * from "./TableNames.js"
 export * from "./TableDefinitions.js"
+export * from "./TableTypes.js"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./apiutil/logging.js"
 export * from "./apiutil/index.js"
-export * from "./database/TableNames.js"
+export * from "./database/index.js"
 export * from "./main.js"
 
 

--- a/packages/dbadmin/src/controllers/DBAdminApi.ts
+++ b/packages/dbadmin/src/controllers/DBAdminApi.ts
@@ -4,7 +4,7 @@ import { DbAdminApiContext } from "../main.js";
 import { INIT_TABLES_SQL } from "../tools/index.js";
 
 export interface DBAdminApi {
-    init(req: Request, response: Response): void
+    init(request: Request, response: Response): void
 }
 
 export class DBAdminApiImpl implements DBAdminApi {
@@ -12,8 +12,8 @@ export class DBAdminApiImpl implements DBAdminApi {
     constructor(private ctx: DbAdminApiContext) {
     }
     
-    init = async(req: e.Request, response: e.Response) => {
-        logger.requestLog(` * init request received, with body of ${req.headers["content-length"]} bytes`)
+    init = async(request: e.Request, response: e.Response) => {
+        logger.requestLog(` * init request received, with body of ${request.headers["content-length"]} bytes`)
         const result = await this.ctx.dbAdminApiWorker.init(INIT_TABLES_SQL)
         lionwebResponse(response, result.status, {
             success: result.status === HttpSuccessCodes.Ok,

--- a/packages/dbadmin/src/tools/init-tables-sql.ts
+++ b/packages/dbadmin/src/tools/init-tables-sql.ts
@@ -5,7 +5,8 @@ import {
     ORPHANS_NODES_TABLE,
     ORPHANS_PROPERTIES_TABLE, ORPHANS_REFERENCES_TABLE,
     PROPERTIES_TABLE,
-    REFERENCES_TABLE
+    REFERENCES_TABLE, 
+    RESERVED_IDS_TABLE
 } from "@lionweb/repository-common";
 
 export const INIT_TABLES_SQL = `
@@ -18,6 +19,7 @@ DROP TABLE IF EXISTS ${ORPHANS_NODES_TABLE};
 DROP TABLE IF EXISTS ${ORPHANS_CONTAINMENTS_TABLE};
 DROP TABLE IF EXISTS ${ORPHANS_PROPERTIES_TABLE};
 DROP TABLE IF EXISTS ${ORPHANS_REFERENCES_TABLE};
+DROP TABLE IF EXISTS ${RESERVED_IDS_TABLE};
 
 -- Drop indices
 -- DROP INDEX IF EXISTS ContainmentsNodesIndex;
@@ -61,11 +63,20 @@ CREATE TABLE IF NOT EXISTS ${REFERENCES_TABLE} (
     PRIMARY KEY(reference, node_id)
 );
 
--- Create indices to enable finding features for nodes quickly
+-- Creates reserved_ids table
+CREATE TABLE IF NOT EXISTS ${RESERVED_IDS_TABLE} (
+--  r_id         SERIAL  NOT NULL, 
+    node_id      text,
+    client_id    text,
+    PRIMARY KEY(node_id)
+);
+
+-- TODO: Create indices to enable finding features for nodes quickly
 
 -- CREATE INDEX ContainmentsNodesIndex ON ${CONTAINMENTS_TABLE} (node_id)
 -- CREATE INDEX PropertiesNodesIndex   ON ${PROPERTIES_TABLE}   (node_id)
 -- CREATE INDEX ReferencesNodesIndex   ON ${REFERENCES_TABLE}   (node_id)
+-- CREATE INDEX ReservedIdsIndex       ON ${RESERVED_IDS_TABLE} (node_id)
 
 CREATE TABLE IF NOT EXISTS ${ORPHANS_NODES_TABLE} (
     id                  text, 
@@ -93,4 +104,7 @@ CREATE TABLE IF NOT EXISTS ${ORPHANS_REFERENCES_TABLE}   (
     targets      jsonb[],
     node_id      text
 );
+
+INSERT INTO ${RESERVED_IDS_TABLE}(node_id, client_id)
+VALUES('ANN-1', 'Dummy');
 `

--- a/packages/dbadmin/src/tools/init-tables-sql.ts
+++ b/packages/dbadmin/src/tools/init-tables-sql.ts
@@ -105,6 +105,4 @@ CREATE TABLE IF NOT EXISTS ${ORPHANS_REFERENCES_TABLE}   (
     node_id      text
 );
 
-INSERT INTO ${RESERVED_IDS_TABLE}(node_id, client_id)
-VALUES('ANN-1', 'Dummy');
 `

--- a/packages/inspection/src/controllers/InspectionApi.ts
+++ b/packages/inspection/src/controllers/InspectionApi.ts
@@ -2,22 +2,22 @@ import e, { Request, Response } from "express"
 import { InspectionContext } from "../main.js";
 
 export interface InspectionApi {
-    nodesByClassifier(req: Request, response: Response): void
+    nodesByClassifier(request: Request, response: Response): void
 
-    nodesByLanguage(req: Request, response: Response): void
+    nodesByLanguage(request: Request, response: Response): void
 }
 
 class InspectionApiImpl implements InspectionApi {
     constructor(private context: InspectionContext) {
     }
 
-    nodesByClassifier = async (req: e.Request, response: e.Response)=> {
+    nodesByClassifier = async (request: e.Request, response: e.Response)=> {
         const sql = this.context.inspectionQueries.nodesByClassifier();
         const queryResult = await this.context.inspectionApiWorker.nodesByClassifier(sql)
         response.send(queryResult)
     }
 
-    nodesByLanguage = async (req: e.Request, response: e.Response) => {
+    nodesByLanguage = async (request: e.Request, response: e.Response) => {
         const sql = this.context.inspectionQueries.nodesByLanguage();
         const queryResult = await this.context.inspectionApiWorker.nodesByLanguage(sql)
         response.send(queryResult)

--- a/packages/languages/src/controllers/LanguageApi.ts
+++ b/packages/languages/src/controllers/LanguageApi.ts
@@ -3,7 +3,7 @@ import { Request, Response } from "express"
 import { LanguageApiContext } from "../main.js";
 
 export interface LanguageApi {
-    registerLanguage(req: Request, response: Response): void
+    registerLanguage(request: Request, response: Response): void
 }
 
 export class LanguageApiImpl implements LanguageApi {
@@ -11,14 +11,14 @@ export class LanguageApiImpl implements LanguageApi {
     }
     /**
      * Get the tree with root `id`, for one single node
-     * @param req
+     * @param request
      * @param response
      */
-    registerLanguage = async (req: Request, response: Response)=> {
-        console.log("TODO: 'registerLanguage' not implemented yet " + req + " " + response)
+    registerLanguage = async (request: Request, response: Response)=> {
+        console.log("TODO: 'registerLanguage' not implemented yet " + request + " " + response)
         lionwebResponse(response, 501, {
             success: false,
-            messages: [{kind: "NotImplemented", message: "TODO: 'registerLanguage' not implemented yet " + req + " " + response}]
+            messages: [{kind: "NotImplemented", message: "TODO: 'registerLanguage' not implemented yet " + request + " " + response}]
         })
     }
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -31,11 +31,11 @@ app.use(bodyParser.json({limit: process.env.BODY_LIMIT || '50mb'}))
 
 const expectedToken = process.env.EXPECTED_TOKEN
 
-function verifyToken(req: Request, res: Response, next: NextFunction) {
+function verifyToken(request: Request, response: Response, next: NextFunction) {
     if (expectedToken != null) {
-        const providedToken = req.headers['authorization']
+        const providedToken = request.headers['authorization']
         if (providedToken == null || typeof providedToken !== "string" || providedToken.trim() != expectedToken) {
-            return res.status(HttpClientErrors.Unauthorized).send("Invalid token or no token provided")
+            return response.status(HttpClientErrors.Unauthorized).send("Invalid token or no token provided")
         } else {
             next();
         }

--- a/packages/test/src/test/RepositoryClient.ts
+++ b/packages/test/src/test/RepositoryClient.ts
@@ -8,10 +8,17 @@ export type ClientResponse = {
     status: Status
 }
 
+const CLIENT_ID = "TestClient"
+
 export class RepositoryClient {
     private _nodePort = process.env.NODE_PORT || 3005
     private _SERVER_IP = "http://127.0.0.1"
     private _SERVER_URL = `${this._SERVER_IP}:${this._nodePort}/`
+    private clientId: string
+    
+    constructor() {
+        this.clientId = CLIENT_ID
+    }
 
     readModel(filename: string): LionWebJsonChunk | null {
         if (fs.existsSync(filename)) {
@@ -37,7 +44,7 @@ export class RepositoryClient {
     async testCreatePartitions(data: LionWebJsonChunk): Promise<ClientResponse> {
         console.log(`test.testCreatePartitions`)
         if (data === null) {
-            console.log("Cannot read json data")
+            console.log("testCreatePartitions: Cannot read json data")
             return { status: HttpClientErrors.PreconditionFailed, body: { result: "Repository.testClient: cannot read partitions to create"} }
         }
         console.log("Create partition " + JSON.stringify(data))
@@ -48,7 +55,7 @@ export class RepositoryClient {
     async testDeletePartitions(partitionIds: string[]): Promise<ClientResponse> {
         console.log(`test.testDeletePartitions`)
         if (partitionIds === null) {
-            console.log("Cannot read partitions")
+            console.log("testDeletePartitions: Cannot read partitions")
             return { status: HttpClientErrors.PreconditionFailed, body: { result: "Repository.testClient: cannot read partitions to delete"} }
         }
         console.log("Delete partition " + partitionIds)
@@ -59,7 +66,7 @@ export class RepositoryClient {
     async testStore(data: LionWebJsonChunk): Promise<ClientResponse> {
         console.log(`test.store`)
         if (data === null) {
-            console.log("Cannot read json data")
+            console.log("testStore: Cannot read json data")
             return { status: HttpClientErrors.PreconditionFailed, body: { result: "Repository.testClient: cannot read data to store"} }
         }
         const result = await this.postWithTimeout(`bulk/store`, { body: data, params: "" })
@@ -165,9 +172,9 @@ export class RepositoryClient {
 
     private findParams(params?: string): string {
         if (!!params && params.length > 0) {
-            return "?" + params + ";clientId=TestClient"
+            return "?" + params + "&clientId=" + this.clientId
         } else {
-            return "?clientId=TestClient"
+            return "?clientId=" + this.clientId
         }
     }
 

--- a/packages/test/src/test/RepositoryClient.ts
+++ b/packages/test/src/test/RepositoryClient.ts
@@ -30,7 +30,7 @@ export class RepositoryClient {
     }
 
     async testPartitions(): Promise<PartitionsResponse> {
-        const partitionsResponse: PartitionsResponse = await this.getWithTimeout<PartitionsResponse>("bulk/partitions", { body: {}, params: "" })
+        const partitionsResponse: PartitionsResponse = await this.getWithTimeout<PartitionsResponse>("bulk/listPartitions", { body: {}, params: "" })
         return partitionsResponse
     }
 
@@ -165,9 +165,9 @@ export class RepositoryClient {
 
     private findParams(params?: string): string {
         if (!!params && params.length > 0) {
-            return "?" + params
+            return "?" + params + ";clientId=TestClient"
         } else {
-            return ""
+            return "?clientId=TestClient"
         }
     }
 

--- a/packages/test/src/test/RepositoryClient.ts
+++ b/packages/test/src/test/RepositoryClient.ts
@@ -79,6 +79,12 @@ export class RepositoryClient {
         return x
     }
 
+    async testIds(clientId: string, count: number): Promise<ClientResponse> {
+        console.log(`test.testIds`)
+        const result = await this.postWithTimeout(`bulk/ids`, { body: {}, params: `clientId=${clientId}&count=${count}` })
+        return result
+    }
+
     async testRetrieve(nodeIds: string[], depth?: number): Promise<ClientResponse> {
         console.log(`test.testRetrieve ${nodeIds} with depth ${depth}`)
         const params = (depth === undefined) ? "" : `depthLimit=${depth}`
@@ -171,7 +177,9 @@ export class RepositoryClient {
     }
 
     private findParams(params?: string): string {
-        if (!!params && params.length > 0) {
+        if (!!params && params.includes("clientId")) {
+            return "?" + params
+        } else if (!!params && params.length > 0) {
             return "?" + params + "&clientId=" + this.clientId
         } else {
             return "?clientId=" + this.clientId


### PR DESCRIPTION
Updates to latest spec

- Add mandatory `clientId` to all methods. (needs changes in current clients)
- Rename `partitions` to `listPartitions`.  (needs changes in current clients)
- Remove `mode` parameter from `retrieve`.
- Add and implement `ids`.
