### PR TITLE
Prevent range error issue

### DIFF
--- a/packages/common/src/apiutil/functions.ts
+++ b/packages/common/src/apiutil/functions.ts
@@ -90,6 +90,7 @@ export function runWithTry(func: (request: Request, response: Response) => void)
         try {
             await func(request, response)
         } catch (e) {
+            console.log(e.stack);
             const error = asError(e)
             console.log(`Exception while serving request for ${request.url}: ${error.message}`)
             lionwebResponse(response, HttpServerErrors.InternalServerError, {

--- a/packages/common/src/apiutil/functions.ts
+++ b/packages/common/src/apiutil/functions.ts
@@ -90,9 +90,9 @@ export function runWithTry(func: (request: Request, response: Response) => void)
         try {
             await func(request, response)
         } catch (e) {
-            console.log(e.stack);
             const error = asError(e)
             console.log(`Exception while serving request for ${request.url}: ${error.message}`)
+            console.log(e.stack);
             lionwebResponse(response, HttpServerErrors.InternalServerError, {
                 success: false,
                 messages: [{ kind: error.name, message: `Exception while serving request for ${request.url}: ${error.message}` }]

--- a/packages/inspection/src/controllers/InspectionApi.ts
+++ b/packages/inspection/src/controllers/InspectionApi.ts
@@ -1,5 +1,6 @@
 import e, { Request, Response } from "express"
 import { InspectionContext } from "../main.js";
+import {ClassifierNodes, LanguageNodes} from "../database/InspectionApiWorker";
 
 export interface InspectionApi {
     nodesByClassifier(request: Request, response: Response): void
@@ -7,20 +8,99 @@ export interface InspectionApi {
     nodesByLanguage(request: Request, response: Response): void
 }
 
+/**
+ * We use this class to track a cursor over a Buffer and to
+ * allocate a new one when necessary.
+ */
+class BufferHolder {
+    private buffer = Buffer.alloc(1000000)
+    private usedSize: number = 0
+    getBuffer() {
+        // We return only the part of the buffer actually filled with data
+        const res = this.buffer.subarray(0, this.usedSize)
+        return res
+    }
+
+    write(string: string) {
+        const stringLength = Buffer.byteLength(string)
+        const remainingSize = this.buffer.length - this.usedSize
+        if (remainingSize < stringLength) {
+            const oldBuffer = this.buffer
+            this.buffer = Buffer.alloc(oldBuffer.length * 2)
+            oldBuffer.copy(this.buffer)
+            // Perhaps we need to grow again the buffer, so we make
+            // another call to this method to re-check the size
+            return this.write(string)
+        } else {
+            this.buffer.write(string, this.usedSize)
+            this.usedSize += stringLength
+        }
+    }
+}
+
 class InspectionApiImpl implements InspectionApi {
     constructor(private context: InspectionContext) {
+    }
+
+    private serializeInBufferIDsList(buffer: BufferHolder, ids: string[], limit: number) {
+        const idsToSend = (limit < 0 || limit >= ids.length) ? ids : ids.slice(0, limit)
+        idsToSend.forEach((id, index)=>{
+            if (index != 0) {
+                buffer.write(",\n")
+            }
+            buffer.write(`"${id}"`)
+        })
+    }
+
+    private classifierNodesToBuffer(classifierNodes: ClassifierNodes[], limit: number): Buffer {
+        const bufferHolder = new BufferHolder()
+        bufferHolder.write("[")
+        classifierNodes.forEach((element, index)=>{
+            if (index != 0) {
+                bufferHolder.write(",")
+            }
+            bufferHolder.write(`{"language"="${element.language}",`)
+            bufferHolder.write(`"classifier"="${element.classifier}",`)
+            bufferHolder.write(`"ids"=[`)
+            this.serializeInBufferIDsList(bufferHolder, element.ids, limit)
+            bufferHolder.write(`], "size"=${element.size}}\n`)
+        })
+        bufferHolder.write("]")
+        return bufferHolder.getBuffer()
+    }
+
+    private languageNodesToBuffer(languageNodes: LanguageNodes[], limit: number): Buffer {
+        const bufferHolder = new BufferHolder()
+        bufferHolder.write("[")
+        languageNodes.forEach((element, index)=>{
+            if (index != 0) {
+                bufferHolder.write(",")
+            }
+            bufferHolder.write(`"language"="${element.language}","`)
+            bufferHolder.write(`"ids"=[`)
+            this.serializeInBufferIDsList(bufferHolder, element.ids, limit)
+            bufferHolder.write(`"], size"=${element.size}"`)
+        })
+        bufferHolder.write("]")
+        return bufferHolder.getBuffer()
     }
 
     nodesByClassifier = async (request: e.Request, response: e.Response)=> {
         const sql = this.context.inspectionQueries.nodesByClassifier();
         const queryResult = await this.context.inspectionApiWorker.nodesByClassifier(sql)
-        response.send(queryResult)
+        const limitStr = request.query.limit
+        // TODO handle the case in which multiple query parameters are specified
+        let limit: number = limitStr === undefined ? -1 : parseInt(limitStr as string, 10)
+        response.send(this.classifierNodesToBuffer(queryResult, limit))
     }
 
     nodesByLanguage = async (request: e.Request, response: e.Response) => {
         const sql = this.context.inspectionQueries.nodesByLanguage();
         const queryResult = await this.context.inspectionApiWorker.nodesByLanguage(sql)
-        response.send(queryResult)
+        const limitStr = request.query.limit
+        // TODO handle the case in which multiple query parameters are specified
+        let limit: number = limitStr === undefined ? -1 : parseInt(limitStr as string, 10)
+        response.send(this.languageNodesToBuffer(queryResult, limit))
     }
 }
 

--- a/packages/inspection/src/database/InspectionApiWorker.ts
+++ b/packages/inspection/src/database/InspectionApiWorker.ts
@@ -4,8 +4,7 @@ const MAX_NUMBER_OF_IDS = 5000
 
 export interface LanguageNodes {
     language: string,
-    ids?: [string],
-    tooMany: boolean,
+    ids: [string],
     size: number
 }
 
@@ -16,8 +15,7 @@ export interface LanguageNodes {
 export interface ClassifierNodes {
     language: string,
     classifier: string,
-    ids?: [string],
-    tooMany: boolean,
+    ids: [string],
     size: number
 }
 
@@ -32,42 +30,23 @@ export class InspectionApiWorker {
     async nodesByLanguage(sql: string) {
         return (await this.context.dbConnection.query(sql) as [object]).map(el => {
             const ids = el["ids"].split(",");
-            if (ids.length> MAX_NUMBER_OF_IDS) {
-                return {
-                    "language": el["classifier_language"],
-                    "tooMany":true,
-                    "size": ids.length
-                } as LanguageNodes
-            } else {
-                return {
-                    "language": el["classifier_language"],
-                    "ids": ids,
-                    "tooMany": false,
-                    "size": ids.length
-                } as LanguageNodes
-            }
+            return {
+                "language": el["classifier_language"],
+                "ids": ids,
+                "size": ids.length
+            } as LanguageNodes
         })
     }
 
     async nodesByClassifier(sql: string) {
         return (await this.context.dbConnection.query(sql) as [object]).map(el => {
             const ids = el["ids"].split(",");
-            if (ids.length> MAX_NUMBER_OF_IDS) {
-                return {
-                    "language": el["classifier_language"],
-                    "classifier": el["classifier_key"],
-                    "tooMany":true,
-                    "size": ids.length
-                } as ClassifierNodes
-            } else {
-                return {
-                    "language": el["classifier_language"],
-                    "classifier": el["classifier_key"],
-                    "ids": ids,
-                    "tooMany":false,
-                    "size": ids.length
-                } as ClassifierNodes
-            }
+            return {
+                "language": el["classifier_language"],
+                "classifier": el["classifier_key"],
+                "ids": ids,
+                "size": ids.length
+            } as ClassifierNodes
         })
     }
 }


### PR DESCRIPTION
Fix #49 

We have calls where we return a map from either language or concept to node IDs.
The problem is that when we have a lot of Node IDs (hundreds of thousands of Node IDs) we cannot serialize them to JSON.
Using JSON.stringify fails, but also building the JSON string directly fails.
So these calls now return all the Node IDs if they are below a certain threshold, otherwise they just return their number.
We could later introduce a call using pagination to use to ask for all the node ids having a specific concept or language (and not the entire map for all concepts or all languages)