### PR TITLE
Add possibility to configure root certificate

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: tsc
         run: npm run build
 
-      - name: Create and iniitialize Postgres database
+      - name: Create and initialize Postgres database
         # Runs a script that creates a PostgreSQL table, populates
         # the table with data, and then retrieves the data.
         run: node packages/dbadmin/dist/tools/database.js create && node packages/dbadmin/dist/tools/database.js init      

--- a/configuration.md
+++ b/configuration.md
@@ -17,7 +17,9 @@ Environment variables can be used to configure the project:
 * **PGUSER** (default `postgres`): The username used to connect to the Postgres server
 * **PGPASSWORD** (default `lionweb`): The password used to connect to the Postgres server
 * **PGROOTCERT** (default _none_): If present, the root certificate is used to verify SSL connections. 
-  It should indicate a file.
+  It should indicate a file. It should not be used with `PGROOTCERTCONTENT`.
+* **PGROOTCERTCONTENT** (default _none_): If present, the root certificate is used to verify SSL connections.
+    It should indicate the content of the file certificate. It should not be used with `PGROOTCERT`.
 
 ## Node application configuration
 

--- a/configuration.md
+++ b/configuration.md
@@ -16,6 +16,8 @@ Environment variables can be used to configure the project:
   To avoid such confusion, we use a different environment variable.
 * **PGUSER** (default `postgres`): The username used to connect to the Postgres server
 * **PGPASSWORD** (default `lionweb`): The password used to connect to the Postgres server
+* **PGROOTCERT** (default _none_): If present, the root certificate is used to verify SSL connections. 
+  It should indicate a file.
 
 ## Node application configuration
 

--- a/packages/dbadmin/src/tools/configuration.ts
+++ b/packages/dbadmin/src/tools/configuration.ts
@@ -3,3 +3,4 @@ export const PGUSER = process.env.PGUSER || "postgres"
 export const PGDB = process.env.PGDB ||  "lionweb_test"
 export const PGPASSWORD = process.env.PGPASSWORD || "lionweb"
 export const PGPORT = parseInt(process.env.PGPORT || "5432", 10)
+export const PGROOTCERT = process.env.PGROOTCERT || undefined

--- a/packages/dbadmin/src/tools/configuration.ts
+++ b/packages/dbadmin/src/tools/configuration.ts
@@ -4,3 +4,4 @@ export const PGDB = process.env.PGDB ||  "lionweb_test"
 export const PGPASSWORD = process.env.PGPASSWORD || "lionweb"
 export const PGPORT = parseInt(process.env.PGPORT || "5432", 10)
 export const PGROOTCERT = process.env.PGROOTCERT || undefined
+export const PGROOTCERTCONTENT = process.env.PGROOTCERTCONTENT || undefined

--- a/packages/dbadmin/src/tools/database.ts
+++ b/packages/dbadmin/src/tools/database.ts
@@ -1,7 +1,6 @@
 // import pgPromise from "pg-promise"
-import { PGDB, PGHOST, PGPASSWORD, PGPORT, PGUSER } from "./configuration.js";
-// import { CREATE_DATABASE_SQL } from "./create-database-sql.js"
-// import { INIT_TABLES_SQL } from "./init-tables-sql.js"
+import { PGDB, PGHOST, PGPASSWORD, PGPORT, PGUSER, PGROOTCERT } from "./configuration.js";
+import * as fs from "node:fs";
 
 export type PostgresConfig = {
     host: string
@@ -9,6 +8,7 @@ export type PostgresConfig = {
     user: string
     database?: string
     password: string
+    ssl?: { ca: string }
 }
 
 export const CREATE_CONFIG: PostgresConfig = {
@@ -22,59 +22,8 @@ export const INIT_CONFIG: PostgresConfig = {
     database: PGDB,
     port: PGPORT,
     user: PGUSER,
-    password: PGPASSWORD
+    password: PGPASSWORD,
+    ssl: PGROOTCERT === PGROOTCERT ? undefined : {
+        ca: fs.readFileSync(PGROOTCERT).toString(),
+    },
 }
-
-// const init = async (config: PostgresConfig, sqlCommands: string) => {
-//     console.log("dummy init " + JSON.stringify(config) )
-//     console.log("SQL: " + sqlCommands)
-//     // try {
-//     //     // connect to the local database server
-//     //     const pgp = pgPromise()
-//     //     console.log("config " + JSON.stringify(config, null, 2))
-//     //     const db = pgp(config)
-//     //
-//     //     const sql = sqlCommands
-//     //     console.log("FS: " + JSON.stringify(sql))
-//     //     // split the file into separate statements
-//     //     const statements = sql.split(/;\s*$/m)
-//     //     for (const statement of statements) {
-//     //         if (statement.length > 3) {
-//     //             // execute each of the statements
-//     //             console.log("STATEMENT " + statement)
-//     //             await db.query(statement)
-//     //         }
-//     //     }
-//     //     console.log("Done SQLing")
-//     // } catch (err) {
-//     //     console.error("ERROR: " + err)
-//     //     throw err
-//     // }
-//     return true
-// }
-//
-// let command = process.argv[2]
-// let sqlCommands = ""
-// let config: PostgresConfig | null = null
-// command = "create"
-// if (command === "create") {
-//     sqlCommands = CREATE_DATABASE_SQL
-//     // Environment without database name
-//     config = CREATE_CONFIG
-// } else if (command === "init") {
-//     sqlCommands = INIT_TABLES_SQL
-//     config = INIT_CONFIG
-// } else {
-//     console.log("Usage: node database (create | init)")
-//     process.exit(1)
-// }
-// //
-// init(config, sqlCommands)
-//     .then(() => {
-//         console.log("finished ok")
-//         // process.exit(0)
-//     })
-//     .catch(e => {
-//         console.log("finished with errors: " + JSON.stringify(e))
-//         // process.exit(1)
-//     })

--- a/packages/dbadmin/src/tools/database.ts
+++ b/packages/dbadmin/src/tools/database.ts
@@ -1,5 +1,5 @@
 // import pgPromise from "pg-promise"
-import { PGDB, PGHOST, PGPASSWORD, PGPORT, PGUSER, PGROOTCERT } from "./configuration.js";
+import {PGDB, PGHOST, PGPASSWORD, PGPORT, PGUSER, PGROOTCERT, PGROOTCERTCONTENT} from "./configuration.js";
 import * as fs from "node:fs";
 
 export type PostgresConfig = {
@@ -17,13 +17,22 @@ export const CREATE_CONFIG: PostgresConfig = {
     user: PGUSER,
     password: PGPASSWORD
 }
+
+if (PGROOTCERT && PGROOTCERTCONTENT) {
+    throw Error("PGROOTCERT and PGROOTCERTCONTENT should not be set at the same time")
+}
+export let pgSSLConf = undefined
+if (PGROOTCERTCONTENT) {
+    pgSSLConf = {ca: PGROOTCERTCONTENT}
+} else if (PGROOTCERT) {
+    pgSSLConf = {ca: fs.readFileSync(PGROOTCERT).toString()}
+}
+
 export const INIT_CONFIG: PostgresConfig = {
     host: PGHOST,
     database: PGDB,
     port: PGPORT,
     user: PGUSER,
     password: PGPASSWORD,
-    ssl: PGROOTCERT === PGROOTCERT ? undefined : {
-        ca: fs.readFileSync(PGROOTCERT).toString(),
-    },
+    ssl: pgSSLConf
 }

--- a/packages/server/src/DbConnection.ts
+++ b/packages/server/src/DbConnection.ts
@@ -1,7 +1,17 @@
 import { logger } from "@lionweb/repository-common";
-import { PGDB, PGHOST, PGPASSWORD, PGPORT, PGUSER, CREATE_CONFIG, INIT_CONFIG, PostgresConfig } from "@lionweb/repository-dbadmin";
+import {
+    PGDB,
+    PGHOST,
+    PGPASSWORD,
+    PGPORT,
+    PGUSER,
+    CREATE_CONFIG,
+    PostgresConfig,
+    PGROOTCERT
+} from "@lionweb/repository-dbadmin";
 import pgPromise from "pg-promise"
 import dotenv from "dotenv"
+import fs from "node:fs";
 
 // Initialize and export the database connection with configuration from _env_
 
@@ -13,10 +23,13 @@ export const config: PostgresConfig = {
     port: PGPORT,
     user: PGUSER,
     password: PGPASSWORD,
+    ssl: PGROOTCERT === undefined ? undefined : {
+        ca: fs.readFileSync(PGROOTCERT).toString(),
+    },
 }
 
 logger.dbLog("POSTGRES CONFIG: " + JSON.stringify(config, null, 2))
 
 export const pgp = pgPromise()
-export const dbConnection = pgp(INIT_CONFIG)
+export const dbConnection = pgp(config)
 export const postgresConnection = pgp(CREATE_CONFIG)

--- a/packages/server/src/DbConnection.ts
+++ b/packages/server/src/DbConnection.ts
@@ -7,7 +7,7 @@ import {
     PGUSER,
     CREATE_CONFIG,
     PostgresConfig,
-    PGROOTCERT
+    pgSSLConf
 } from "@lionweb/repository-dbadmin";
 import pgPromise from "pg-promise"
 import dotenv from "dotenv"
@@ -23,9 +23,7 @@ export const config: PostgresConfig = {
     port: PGPORT,
     user: PGUSER,
     password: PGPASSWORD,
-    ssl: PGROOTCERT === undefined ? undefined : {
-        ca: fs.readFileSync(PGROOTCERT).toString(),
-    },
+    ssl: pgSSLConf
 }
 
 logger.dbLog("POSTGRES CONFIG: " + JSON.stringify(config, null, 2))


### PR DESCRIPTION
This may be needed to connect through SSL to Postgres.
For example, this is needed to connect to an instance hosted on Digital Ocean.

I also correct a typo in a GitHub action and remove some commented out code.