### PR TITLE
Correct getNodeTree

### DIFF
--- a/packages/additionalapi/src/controllers/AdditionalApi.ts
+++ b/packages/additionalapi/src/controllers/AdditionalApi.ts
@@ -24,6 +24,17 @@ export class AdditionalApiImpl implements AdditionalApi {
      */
     getNodeTree = async (request: Request, response: Response): Promise<void> => {
         const idList = request.body.ids
+        if (idList === undefined) {
+            lionwebResponse(response, HttpClientErrors.BadRequest, {
+                success: false,
+                messages: [{
+                    kind: "EmptyIdList",
+                    message: "ids not found",
+                    data: idList
+                }]
+            })
+            return
+        }
         const clientId = getStringParam(request, "clientId", "Dummy")
         if (isParameterError(clientId)) {
             lionwebResponse(response, HttpClientErrors.BadRequest, {
@@ -42,8 +53,11 @@ export class AdditionalApiImpl implements AdditionalApi {
         } else {
             dbLogger.info("API.getNodeTree is " + idList)
             const result = await this.context.additionalApiWorker.getNodeTree(repositoryData, idList, depthLimit)
-            lionwebResponse(response, HttpSuccessCodes.Ok, EMPTY_SUCCES_RESPONSE)
-            response.send(result)
+            lionwebResponse(response, HttpSuccessCodes.Ok, {
+                success: true,
+                messages: [],
+                data: result.queryResult
+            })
         }
     }
 }

--- a/packages/additionalapi/src/controllers/AdditionalApi.ts
+++ b/packages/additionalapi/src/controllers/AdditionalApi.ts
@@ -18,7 +18,8 @@ export class AdditionalApiImpl implements AdditionalApi {
     constructor(private context: AdditionalApiContext) {
     }
     /**
-     * Get the tree with root `id`, for one single node
+     * Get the tree with root `id`, for a list of node ids.
+     * Note that the tree could be overlapping, and the same nodes could appear multiple times in the response.
      * @param request
      * @param response
      */

--- a/packages/additionalapi/src/controllers/AdditionalApi.ts
+++ b/packages/additionalapi/src/controllers/AdditionalApi.ts
@@ -6,7 +6,7 @@ import {
     getIntegerParam, getRepositoryParameter, getStringParam,
     HttpClientErrors,
     HttpSuccessCodes, isParameterError,
-    lionwebResponse,
+    lionwebResponse, ParameterError,
     RepositoryData
 } from "@lionweb/repository-common"
 
@@ -24,10 +24,13 @@ export class AdditionalApiImpl implements AdditionalApi {
      */
     getNodeTree = async (request: Request, response: Response): Promise<void> => {
         const idList = request.body.ids
-        let clientId = getStringParam(request, "clientId")
+        const clientId = getStringParam(request, "clientId", "Dummy")
         if (isParameterError(clientId)) {
-            // Allow call without client id
-            clientId = "Dummy"
+            lionwebResponse(response, HttpClientErrors.BadRequest, {
+                success: false,
+                messages: [(clientId as ParameterError).error]
+            })
+            return
         }
         const repositoryData: RepositoryData = { clientId: clientId, repository: getRepositoryParameter(request) }
         const depthLimit = getIntegerParam(request, "depthLimit", Number.MAX_SAFE_INTEGER)

--- a/packages/additionalapi/src/main.ts
+++ b/packages/additionalapi/src/main.ts
@@ -38,5 +38,5 @@ export function registerAdditionalApi(app: Express, dbConnection: DbConnection, 
     const context = new AdditionalApiContext(dbConnection, pgp)
 
     // Add routes to application
-    app.get("/additional/getNodeTree", runWithTry(context.additionalApi.getNodeTree))
+    app.post("/additional/getNodeTree", runWithTry(context.additionalApi.getNodeTree))
 }

--- a/packages/common/src/apiutil/functions.ts
+++ b/packages/common/src/apiutil/functions.ts
@@ -193,7 +193,6 @@ export function runWithTry(func: (request: Request, response: Response) => void)
         try {
             await func(request, response)
         } catch (e) {
-            console.log(e.stack);
             const error = asError(e)
             requestLogger.error(`Exception while serving request for ${request.url}: ${error.message}`)
             requestLogger.error(error)

--- a/packages/common/src/apiutil/functions.ts
+++ b/packages/common/src/apiutil/functions.ts
@@ -193,6 +193,7 @@ export function runWithTry(func: (request: Request, response: Response) => void)
         try {
             await func(request, response)
         } catch (e) {
+            console.log(e.stack);
             const error = asError(e)
             requestLogger.error(`Exception while serving request for ${request.url}: ${error.message}`)
             requestLogger.error(error)


### PR DESCRIPTION
This PR has been verified through a test in LionWeb Kotlin (see https://github.com/LionWeb-io/lionweb-kotlin/pull/1)

Changes:
* Documentation of the method. The method supports receiving multiple ids, but the documentation was stating otherwise
* I was getting an error when not specifying the clientId, and I think this was the intended behavior. I changed it in a way that providing no clientId should work, but providing somehow an invalid string should fail
* The way in which we were providing the answer was incorrect

Note that this PR is based on top of #76 