### PR TITLE
Updates to configuration for DB creation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,11 +57,3 @@ jobs:
           npm run -w @lionweb/repository-server dev &
           sleep 6
           npm run test
-        # Environment variables used by the `client.js` script to create a new PostgreSQL table.
-        env:
-          # The hostname used to communicate with the PostgreSQL service container
-          PGHOST: postgres
-          # The default PostgreSQL port
-          PGPORT: 5432
-          PGUSER: postgres
-          PGPASSWORD: lionweb

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,11 +47,6 @@ jobs:
       - name: tsc
         run: npm run build
 
-      - name: Create and initialize Postgres database
-        # Runs a script that creates a PostgreSQL table, populates
-        # the table with data, and then retrieves the data.
-        run: node packages/dbadmin/dist/tools/database.js create && node packages/dbadmin/dist/tools/database.js init      
-      
       - name: start server and run tests (one step, else server will be down when tests start)
         run: |
           npm run -w @lionweb/repository-server dev &

--- a/configuration.md
+++ b/configuration.md
@@ -51,6 +51,8 @@ Below is the server-config.json with all default values
       "host": "postgres",
       // The username used to connect to the Postgres server
       "user": "postgres",
+      // The name of the admin database
+      maintenanceDb: "postgres" ,
       // The name of the Postgres database to be used within the Postgres server.
       "db": "lionweb",
       // The password used to connect to the Postgres server

--- a/configuration.md
+++ b/configuration.md
@@ -23,8 +23,8 @@ Below is the server-config.json with all default values
 
   },
   "startup": {
-    // Whether to create a new databse at startup.
-    // Note that the new dartabase will overwrite any existing database  
+    // Whether to create a new database at startup.
+    // Note that the new database will overwrite any existing database  
     "createDatabase": true,
     // The list of repositories to be created at start uo, can be empty
     "createRepositories": [

--- a/configuration.md
+++ b/configuration.md
@@ -1,7 +1,13 @@
 # Configuration
 
-The file server-config.json is used to configure the server:
-It should be in the same folder where the  server is started, if it does not exists, default values will be used"
+The file `server-config.json` is used to configure the server:
+It should be in the same folder where the server is started, if it does not exist, default values will be used.
+
+It is possible to specify a different path for the configuration file.
+For example:
+```
+npm run dev ../../../lwrepo-conf/server-config.json
+```
 
 Below is the server-config.json with all default values
 
@@ -68,23 +74,16 @@ Below is the server-config.json with all default values
 
 ## Database configuration
 
-* **PGDB** (default `lionweb`): The name of the Postgres database to be used within the Postgres server. 
-  Please note that the variable **PGDATABASE** is instead _directly_ accessed by Postgres 
-  (see [Postrgres references](https://www.postgresql.org/docs/current/libpq-envars.html). 
-  This is an issue when running the database create script. In that case Postgress would use the **PGDATABASE**
-  to determine the name of the database that it should connect to. However, we would use it as the name of the database
-  to be created. This would cause a very confusing error because it would appear that the CREATE DATABASE statement 
-  would fail precisely because the database we want to create does not exist. 
-  To avoid such confusion, we use a different environment variable.
+* **postgres.database** (default `lionweb`): The name of the Postgres database to be used within the Postgres server.
 
 ## Node application configuration
 
-* **NODE_PORT** (default `3005`): Port at which the lionweb repository can be reached
-* **BODY_LIMIT** (default `50mb`): Maximum size of the body requests accepted by the lionweb repository
+* **server.serverPort** (default `3005`): Port at which the lionweb repository can be reached
+* **server.bodyLimit** (default `50mb`): Maximum size of the body requests accepted by the lionweb repository
 
 ## Other configuration parameters
 
-* **DB_VERBOSITY** (default `false`): Print queries and other information related to the DB
-* **REQUESTS_VERBOSITY** (default `true`): Print logs about the requested received
-* **EXPECTED_TOKEN** (default to _no token_): When a token is specified, it should be provided in all calls. 
-  Otherwise they would be rejected.
+* **logging.database** (default `silent`): Print queries and other information related to the DB
+* **logging.request** (default `info`): Print logs about the requested received
+* **server.expectedToken** (default to _no token_): When a token is specified, it should be provided in all calls. 
+  Otherwise, they would be rejected.

--- a/packages/common/src/apiutil/ServerConfig.ts
+++ b/packages/common/src/apiutil/ServerConfig.ts
@@ -25,6 +25,7 @@ export type ServerConfigJson = {
             host?: string
             user?: string
             db?: string
+            maintenanceDb?: string
             password?: string
             port?: number
         }
@@ -133,6 +134,11 @@ export class ServerConfig {
     pgDb(): string {
         const result = this?.config?.postgres?.database?.db
         return result || "lionweb"
+    }
+
+    pgMaintenanceDb(): string {
+        const result = this?.config?.postgres?.database?.maintenanceDb
+        return result || "postgres"
     }
 
     pgPassword(): string {

--- a/packages/common/src/apiutil/ServerConfig.ts
+++ b/packages/common/src/apiutil/ServerConfig.ts
@@ -60,15 +60,18 @@ export class ServerConfig {
     readConfigFile(): void {
         let configFile = "./server-config.json"
         const configFlagIndex = process.argv.indexOf("--config")
+        console.log("process.argv", process.argv)
+        console.log("configFlagIndex ", configFlagIndex)
         if (configFlagIndex > -1) {
             const configParam = process.argv[configFlagIndex + 1]
             if (configParam !== undefined) {
                 configFile = configParam
             } else {
-                expressLogger.error("--config <filename>  is missing <filename>")
+                expressLogger.error("--config <filename> is missing <filename>")
                 process.exit(1)
             }
         }
+        console.log("CHECKING CONFIGFILE", configFile)
         if (fs.existsSync(configFile)) {
             const stats = fs.statSync(configFile)
             if (stats.isFile()) {

--- a/packages/common/src/apiutil/ServerConfig.ts
+++ b/packages/common/src/apiutil/ServerConfig.ts
@@ -66,8 +66,10 @@ export class ServerConfig {
             if (configParam !== undefined) {
                 configFile = configParam
             } else {
-                expressLogger.error("--config <filename> is missing <filename>")
-                process.exit(1)
+                // This is not ideal, but because of how `npm run dev` works I could not think of another solution
+                // that works conveniently both to run the server specifying the configuration path and not specifying
+                // it
+                expressLogger.warn("--config <filename> is missing <filename>, using default path ${configFile}`)")
             }
         }
         if (fs.existsSync(configFile)) {

--- a/packages/common/src/apiutil/ServerConfig.ts
+++ b/packages/common/src/apiutil/ServerConfig.ts
@@ -60,8 +60,6 @@ export class ServerConfig {
     readConfigFile(): void {
         let configFile = "./server-config.json"
         const configFlagIndex = process.argv.indexOf("--config")
-        console.log("process.argv", process.argv)
-        console.log("configFlagIndex ", configFlagIndex)
         if (configFlagIndex > -1) {
             const configParam = process.argv[configFlagIndex + 1]
             if (configParam !== undefined) {
@@ -71,7 +69,6 @@ export class ServerConfig {
                 process.exit(1)
             }
         }
-        console.log("CHECKING CONFIGFILE", configFile)
         if (fs.existsSync(configFile)) {
             const stats = fs.statSync(configFile)
             if (stats.isFile()) {

--- a/packages/dbadmin/src/database/DBAdminApiWorker.ts
+++ b/packages/dbadmin/src/database/DBAdminApiWorker.ts
@@ -62,8 +62,10 @@ export class DBAdminApiWorker {
     }
 
     async createDatabase(): Promise<QueryReturnType<string>> {
+        console.log("About to create database")
         const sql = CREATE_DATABASE_SQL
         if (!this.done) {
+            console.log("create database - not done")
             // split the file into separate statements
             const statements = sql.split(/;\s*$/m)
             for (const statement of statements) {
@@ -73,13 +75,16 @@ export class DBAdminApiWorker {
                 }
             }
             // Add the global functions to the public schema
+            console.log("create database - about to query")
             await this.ctx.dbConnection.query({ clientId: "Repository", repository: "public" }, removeNewlinesBetween$$(CREATE_GLOBALS_SQL))
+            console.log("create database - query executed")
             return {
                 status: HttpSuccessCodes.Ok,
                 query: sql,
                 queryResult: "{}"
             }
         } else {
+            console.log("create database - Done")
             return {
                 status: HttpSuccessCodes.Ok,
                 query: sql,

--- a/packages/dbadmin/src/database/DBAdminApiWorker.ts
+++ b/packages/dbadmin/src/database/DBAdminApiWorker.ts
@@ -62,10 +62,8 @@ export class DBAdminApiWorker {
     }
 
     async createDatabase(): Promise<QueryReturnType<string>> {
-        console.log("About to create database")
         const sql = CREATE_DATABASE_SQL
         if (!this.done) {
-            console.log("create database - not done")
             // split the file into separate statements
             const statements = sql.split(/;\s*$/m)
             for (const statement of statements) {
@@ -75,16 +73,13 @@ export class DBAdminApiWorker {
                 }
             }
             // Add the global functions to the public schema
-            console.log("create database - about to query")
             await this.ctx.dbConnection.query({ clientId: "Repository", repository: "public" }, removeNewlinesBetween$$(CREATE_GLOBALS_SQL))
-            console.log("create database - query executed")
             return {
                 status: HttpSuccessCodes.Ok,
                 query: sql,
                 queryResult: "{}"
             }
         } else {
-            console.log("create database - Done")
             return {
                 status: HttpSuccessCodes.Ok,
                 query: sql,

--- a/packages/dbadmin/src/tools/create-database-sql.ts
+++ b/packages/dbadmin/src/tools/create-database-sql.ts
@@ -10,7 +10,6 @@ CREATE DATABASE ${ServerConfig.getInstance().pgDb()}
     LC_COLLATE = 'en_US.UTF-8'
     LC_CTYPE = 'en_US.UTF-8'
     LOCALE_PROVIDER = 'libc'
-    TABLESPACE = pg_default
     CONNECTION LIMIT = -1
     IS_TEMPLATE = False;
 

--- a/packages/dbadmin/src/tools/create-database-sql.ts
+++ b/packages/dbadmin/src/tools/create-database-sql.ts
@@ -7,8 +7,8 @@ CREATE DATABASE ${ServerConfig.getInstance().pgDb()}
     WITH
     OWNER = '${ServerConfig.getInstance().pgUser()}'
     ENCODING = 'UTF8'
-    LC_COLLATE = 'en_US.utf8'
-    LC_CTYPE = 'en_US.utf8'
+    LC_COLLATE = 'en_US.UTF-8'
+    LC_CTYPE = 'en_US.UTF-8'
     LOCALE_PROVIDER = 'libc'
     TABLESPACE = pg_default
     CONNECTION LIMIT = -1

--- a/packages/dbadmin/src/tools/create-database-sql.ts
+++ b/packages/dbadmin/src/tools/create-database-sql.ts
@@ -11,7 +11,8 @@ CREATE DATABASE ${ServerConfig.getInstance().pgDb()}
     LC_CTYPE = 'en_US.UTF-8'
     LOCALE_PROVIDER = 'libc'
     CONNECTION LIMIT = -1
-    IS_TEMPLATE = False;
+    IS_TEMPLATE = False
+    TEMPLATE template0;
 
 GRANT TEMPORARY, CONNECT ON DATABASE ${ServerConfig.getInstance().pgDb()} TO PUBLIC;
 

--- a/packages/dbadmin/src/tools/database.ts
+++ b/packages/dbadmin/src/tools/database.ts
@@ -11,13 +11,6 @@ export type PostgresConfig = {
     ssl?: { ca: string }
 }
 
-export const CREATE_CONFIG: PostgresConfig = {
-    host: ServerConfig.getInstance().pgHost(),
-    port: ServerConfig.getInstance().pgPort(),
-    user: ServerConfig.getInstance().pgUser(),
-    password: ServerConfig.getInstance().pgPassword()
-}
-
 if (ServerConfig.getInstance().pgRootcert() && ServerConfig.getInstance().pgRootcertcontents()) {
     throw Error("PGROOTCERT and PGROOTCERTCONTENT should not be set at the same time")
 }
@@ -28,12 +21,11 @@ if (ServerConfig.getInstance().pgRootcertcontents()) {
     pgSSLConf = {ca: fs.readFileSync(ServerConfig.getInstance().pgRootcert()).toString()}
 }
 
-export const INIT_CONFIG: PostgresConfig = {
+export const CREATE_CONFIG: PostgresConfig = {
     host: ServerConfig.getInstance().pgHost(),
     port: ServerConfig.getInstance().pgPort(),
     user: ServerConfig.getInstance().pgUser(),
     password: ServerConfig.getInstance().pgPassword(),
-    database: ServerConfig.getInstance().pgDb(),
+    database: ServerConfig.getInstance().pgMaintenanceDb(),
     ssl: pgSSLConf
 }
-

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules/ && rm -rf dist/",
-    "dev": "nodemon dist/server.js --config",
+    "dev": "nodemon dist/server.js -- --config",
     "build": "tsc",
     "alive": "echo I am alive",
     "lint": "eslint src",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -75,7 +75,7 @@ const serverPort = ServerConfig.getInstance().serverPort()
 if (ServerConfig.getInstance().createDatabase()) {
     await dbAdminApi.createDatabase()
 }
-// Initialize reppositories
+// Initialize repositories
 for (const repository of ServerConfig.getInstance().createRepositories()) {
     if (repository?.history !== undefined && repository?.history !== null && repository?.history === true) {
         await dbAdminApi.createRepository({clientId: "repository", repository: SCHEMA_PREFIX + repository.name})


### PR DESCRIPTION
Based on the issue discussed in #71 I report some proposals for updates.
This is about problems emerged when running the Postgres database and the LionWeb repository on a linux server, using a DB user different from `postgres`.

This PR:
- update the documentation in `configuration.md`
- correct a couple of typos/extra spaces
- remove the unused `INIT_CONFIG` constant
- introduce the `maintenanceDb` configuration parameter, defaulting to `postgres`
- changes the values used for `LC_COLLATE` and `LC_TYPE`
- remove the explicit reference to tablespace
- add two dashes to in the configuration of the `dev` task, so that command line arguments are passed to the script