### PR TITLE
update listRepositories APIs to provide more information on the repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm run lint
 ```
 
 ### How to start the repository server
-Ensure that Postgress is running.
+Ensure that Postgres is running.
 The repository server is started with `npm run dev-run` in  the `packages/server` folder:
 
 ```

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,8 @@
     "republish-local": "npm run unpublish-local && npm run publish-local"
   },
   "dependencies": {
-    "@lionweb/validation": "0.6.2"
+    "@lionweb/validation": "0.6.2",
+    "@lionweb/repository-common": "0.3.0"
   },
   "devDependencies": {
     "prettier": "3.1.0",

--- a/packages/client/src/responses.ts
+++ b/packages/client/src/responses.ts
@@ -73,5 +73,9 @@ export interface IdsResponse extends LionwebResponse {
 }
 
 export interface ListRepositoriesResponse extends LionwebResponse {
-    repositoryNames: string[]
+    repositories: {
+        name: string
+        lionweb_version: string
+        history: boolean
+    }[]
 }

--- a/packages/client/src/responses.ts
+++ b/packages/client/src/responses.ts
@@ -72,10 +72,15 @@ export interface IdsResponse extends LionwebResponse {
     ids: string[]
 }
 
+/**
+ * Indicates the configuration of an existing repository.
+ */
+export interface RepositoryConfiguration {
+    name: string
+    lionweb_version: string
+    history: boolean
+}
+
 export interface ListRepositoriesResponse extends LionwebResponse {
-    repositories: {
-        name: string
-        lionweb_version: string
-        history: boolean
-    }[]
+    repositories: RepositoryConfiguration[]
 }

--- a/packages/client/src/responses.ts
+++ b/packages/client/src/responses.ts
@@ -3,6 +3,7 @@
  */
 import { LionWebJsonChunk } from "@lionweb/validation";
 import { ClientResponse } from "./RepositoryClient.js";
+import { RepositoryConfiguration } from "@lionweb/repository-common";
 
 export type MessageKind =
     "PartitionHasParent"
@@ -70,15 +71,6 @@ export interface DeletePartitionsResponse extends LionwebResponse {
 
 export interface IdsResponse extends LionwebResponse {
     ids: string[]
-}
-
-/**
- * Indicates the configuration of an existing repository.
- */
-export interface RepositoryConfiguration {
-    name: string
-    lionweb_version: string
-    history: boolean
 }
 
 export interface ListRepositoriesResponse extends LionwebResponse {

--- a/packages/common/src/apiutil/LionwebResponse.ts
+++ b/packages/common/src/apiutil/LionwebResponse.ts
@@ -1,7 +1,6 @@
 import { Response } from "express"
 import { LionWebJsonChunk } from "@lionweb/validation"
 import { JsonStreamStringify } from "json-stream-stringify"
-import { RepositoryConfiguration } from "@lionweb/repository-client";
 
 // "string" is needed as MessageKind can also be any of the ValidationIssue kinds.
 export type MessageKind =
@@ -62,6 +61,15 @@ export interface DeletePartitionsResponse extends LionwebResponse {}
 
 export interface IdsResponse extends LionwebResponse {
     ids: string[]
+}
+
+/**
+ * Indicates the configuration of an existing repository.
+ */
+export interface RepositoryConfiguration {
+    name: string
+    lionweb_version: string
+    history: boolean
 }
 
 export interface ListRepositoriesResponse extends LionwebResponse {

--- a/packages/common/src/apiutil/LionwebResponse.ts
+++ b/packages/common/src/apiutil/LionwebResponse.ts
@@ -1,6 +1,7 @@
 import { Response } from "express"
 import { LionWebJsonChunk } from "@lionweb/validation"
 import { JsonStreamStringify } from "json-stream-stringify"
+import { RepositoryConfiguration } from "@lionweb/repository-client";
 
 // "string" is needed as MessageKind can also be any of the ValidationIssue kinds.
 export type MessageKind =
@@ -64,11 +65,7 @@ export interface IdsResponse extends LionwebResponse {
 }
 
 export interface ListRepositoriesResponse extends LionwebResponse {
-    repositories: {
-        name: string
-        lionweb_version: string
-        history: boolean
-    }[]
+    repositories: RepositoryConfiguration[]
 }
 
 export function lionwebResponse<T extends LionwebResponse>(response: Response, status: number, body: T): void {

--- a/packages/common/src/apiutil/LionwebResponse.ts
+++ b/packages/common/src/apiutil/LionwebResponse.ts
@@ -64,7 +64,11 @@ export interface IdsResponse extends LionwebResponse {
 }
 
 export interface ListRepositoriesResponse extends LionwebResponse {
-    repositoryNames: string[]
+    repositories: {
+        name: string
+        lionweb_version: string
+        history: boolean
+    }[]
 }
 
 export function lionwebResponse<T extends LionwebResponse>(response: Response, status: number, body: T): void {

--- a/packages/common/src/database/DbConnection.ts
+++ b/packages/common/src/database/DbConnection.ts
@@ -12,6 +12,9 @@ export type RepositoryData = {
     repository: RepositoryInfo
 }
 
+/**
+ * Indicates the configuration of a repository that may have yet to be created.
+ */
 export type RepositoryInfo = {
     repository_name: string
     schema_name: string

--- a/packages/dbadmin/src/controllers/DBAdminApi.ts
+++ b/packages/dbadmin/src/controllers/DBAdminApi.ts
@@ -171,9 +171,14 @@ export class DBAdminApiImpl implements DBAdminApi {
         requestLogger.info(
             ` * listRepositories request received, with body of ${request.headers["content-length"]} bytes. ${getClientLog(request)}`
         )
+        const repositories = Array.from(repositoryStore.repositoryName2repository.values()).map(repo => ({
+            name: repo.repository_name,
+            lionweb_version: repo.lionweb_version,
+            history: repo.history
+        }))
         lionwebResponse<ListRepositoriesResponse>(response, HttpSuccessCodes.Ok, {
             success: true,
-            repositoryNames: Array.from(repositoryStore.repositoryName2repository.keys()),
+            repositories,
             messages: []
         })
     }

--- a/packages/test/src/test/tests.ts
+++ b/packages/test/src/test/tests.ts
@@ -64,7 +64,7 @@ collection.forEach(withoutHistory => {
                     "repoVersionAfterPartitionCreated " + initialPartitionVersion + "repoVersionAfterPartitionFilled " + baseFullChunkVersion
                 )
                 const repositories = await client.dbAdmin.listRepositories()
-                console.log("repositories: " + repositories.body.repositoryNames)
+                console.log("repositories: " + JSON.stringify(repositories.body.repositories))
             })
 
             afterEach("a", async function () {
@@ -389,14 +389,17 @@ collection.forEach(withoutHistory => {
                     const currentrepo = withoutHistory ? "MyFirstRepo" : "MyFirstHistoryRepo"
                     {
                         const repositories = await client.dbAdmin.listRepositories()
-                        assert(repositories.body.repositoryNames.length === 1, "There should be exactly one repository")
-                        assert(repositories.body.repositoryNames.includes(currentrepo), "Incorrect repository found: " + repositories.body.repositoryNames)
+                        assert(repositories.body.repositories.length === 1, "There should be exactly one repository")
+                        assert(repositories.body.repositories.some(repo => repo.name === currentrepo), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
+                        assert(repositories.body.repositories.some(repo => repo.history === !withoutHistory), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
                     }
                     await client.dbAdmin.createRepository("Repo2", !withoutHistory, "2023.1")
                     {
                         const repositories = await client.dbAdmin.listRepositories()
-                        assert(repositories.body.repositoryNames.length === 2, "There should be exactly two repositories")
-                        assert(repositories.body.repositoryNames.every(repo => repo === currentrepo || repo === "Repo2"), "Incorrect repository found: " + repositories.body.repositoryNames)
+                        assert(repositories.body.repositories.length === 2, "There should be exactly two repositories")
+                        assert(repositories.body.repositories.every(repo => repo.name === currentrepo || repo.name === "Repo2"), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
+                        assert(repositories.body.repositories.every(repo => repo.name === currentrepo || repo.lionweb_version === "2023.1"), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
+                        assert(repositories.body.repositories.every(repo => repo.name === currentrepo || repo.history === !withoutHistory), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
                     }
 
                     const createResult = await client.dbAdmin.createRepository("Repo2", true, "2023.1")
@@ -405,15 +408,15 @@ collection.forEach(withoutHistory => {
                     {
                         assert(delete2.body.success === true, "Should be able to delete existiung repository")
                         const repositories = await client.dbAdmin.listRepositories()
-                        assert(repositories.body.repositoryNames.length === 1, "There should be exactly one repository")
-                        assert(repositories.body.repositoryNames.includes(currentrepo), "Incorrect repository found: " + repositories.body.repositoryNames)
+                        assert(repositories.body.repositories.length === 1, "There should be exactly one repository")
+                        assert(repositories.body.repositories.some(repo => repo.name === currentrepo), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
                     }
                     const createResult2 = await client.dbAdmin.createRepository("Repo2", !withoutHistory, "2023.1")
                     {
                         assert(createResult2.body.success === true, "Should  be able to create existing repository: " + JSON.stringify(createResult2.body.messages))
                         const repositories = await client.dbAdmin.listRepositories()
-                        assert(repositories.body.repositoryNames.length === 2, "There should be exactly two repositories")
-                        assert(repositories.body.repositoryNames.every(repo => repo === currentrepo || repo === "Repo2"), "Incorrect repository found: " + repositories.body.repositoryNames)
+                        assert(repositories.body.repositories.length === 2, "There should be exactly two repositories")
+                        assert(repositories.body.repositories.every(repo => repo.name === currentrepo || repo.name === "Repo2"), "Incorrect repository found: " + JSON.stringify(repositories.body.repositories))
                     }
                 })
             })


### PR DESCRIPTION
Currently the APIs specify just the name of the repositories but it may be useful to get also the lionweb version and the flag specifying if they support versioning.