### PR TITLE
Ensure we initialize the repository store

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -144,6 +144,7 @@ async function setupDatabase() {
     }
 
     // Initialize repositories
+    await repositoryStore.initialize()
     const existingRepositoryNames = repositoryStore.allRepositories().map(r => r.repository_name)
     requestLogger.info("Existing repositories " + existingRepositoryNames)
     for (const repository of ServerConfig.getInstance().createRepositories()) {


### PR DESCRIPTION
This is necessary because otherwise the list of repositories appear to be empty and we end up recreating existing repositories even when we should not. This cause the insert the in the repository table to fail and the setup process to fail.