### PR TITLE
Make client configurable through adding a config object in it's constructor

### DIFF
--- a/packages/client/src/RepositoryClient.ts
+++ b/packages/client/src/RepositoryClient.ts
@@ -7,9 +7,9 @@ import { InspectionApi } from "./InspectionApi.js"
 import { LanguagesApi } from "./LanguagesApi.js"
 
 // Default config values
-const DEFAULT_NODE_PORT = (typeof process !== "undefined" && process.env.NODE_PORT) || "3005"
-const DEFAULT_SERVER_IP = (typeof process !== "undefined" && process.env.REPO_IP) || "127.0.0.1"
-const DEFAULT_TIMEOUT = typeof process !== "undefined" ? Number.parseInt(process.env.TIMEOUT) || 20000 : 20000
+const DEFAULT_NODE_PORT = (process !== undefined && process.env.NODE_PORT) || "3005"
+const DEFAULT_SERVER_IP = (process !== undefined && process.env.REPO_IP) || "127.0.0.1"
+const DEFAULT_TIMEOUT = process !== undefined ? Number.parseInt(process.env.TIMEOUT) || 20000 : 20000
 
 export type Status = number
 /**
@@ -29,7 +29,7 @@ export type ClientConfiguration = {
     repository: string;
     hostname?: string;
     port?: string;
-    authorizationtoken?: string;
+    authorizationToken?: string;
     timeout?: number
 }
 // export type LionWebVersionType = "2023.1" | "2024.1"

--- a/packages/test/src/test/additional-api-tests.ts
+++ b/packages/test/src/test/additional-api-tests.ts
@@ -13,7 +13,7 @@ sm.install()
 
 describe("Client - Additional API tests", () => {
     const repository = "clientAdditionalAPIRepo"
-    const client = new RepositoryClient("TestClient", repository)
+    const client = new RepositoryClient({ clientId: "TestClient", repository: repository })
     let initError: string = ""
 
     before("create database", async function () {

--- a/packages/test/src/test/bulk-import-tests.ts
+++ b/packages/test/src/test/bulk-import-tests.ts
@@ -7,7 +7,7 @@ console.log("bulk-import-tests")
 
 describe("Repository tests for bulkImport API", () => {
     const repository: string = "MyBulkImportRepo"
-    const client = new RepositoryClient("TestClient", repository)
+    const client = new RepositoryClient({ clientId: "TestClient", repository: repository })
     const withHistory = false
     let initError: string = ""
     const lwVersion = "2023.1"

--- a/packages/test/src/test/history-test.ts
+++ b/packages/test/src/test/history-test.ts
@@ -17,7 +17,7 @@ type StoredAst = {
 }
 
 describe("Repository tests", () => {
-    const client = new RepositoryClient("TestHistoryClient", "history")
+    const client = new RepositoryClient({ clientId: "TestHistoryClient", repository: "history" })
     client.loggingOn = true
     let initialPartition: LionWebJsonChunk
     let baseFullChunk: LionWebJsonChunk
@@ -89,7 +89,7 @@ describe("Repository tests", () => {
                 return new Set<string>(response.body.chunk.nodes.map(n => n.id))
             }
 
-            const client = new RepositoryClient("TestHistoryClient", "history-partition-crud")
+            const client = new RepositoryClient({ clientId: "TestHistoryClient", repository: "history-partition-crud" })
             client.dbAdmin.createRepository("history-partition-crud", true, "2023.1")
             const v1 = getRepoVersion(
                 await client.bulk.createPartitions({

--- a/packages/test/src/test/inspectionTests.ts
+++ b/packages/test/src/test/inspectionTests.ts
@@ -11,7 +11,7 @@ sm.install()
 const DATA: string = "./data/"
 
 describe("Repository tests for inspection APIs", () => {
-    const client = new RepositoryClient("InspectionTests", "default")
+    const client = new RepositoryClient({ clientId: "InspectionTests", repository: "default"})
     client.loggingOn = true
     let jsonModel: LionWebJsonChunk
 

--- a/packages/test/src/test/sequentialize-requests-test.ts
+++ b/packages/test/src/test/sequentialize-requests-test.ts
@@ -9,7 +9,7 @@ import { readModel } from "./utils.js"
 sm.install()
 
 describe("Transaction isolation tests", () => {
-    const t = new RepositoryClient("TestClient", "isolation")
+    const t = new RepositoryClient({ clientId: "TestClient", repository: "isolation" })
     t.loggingOn = true
 
     beforeEach("a", async function () {

--- a/packages/test/src/test/tests-issue19.ts
+++ b/packages/test/src/test/tests-issue19.ts
@@ -9,7 +9,7 @@ sm.install()
 const DATA: string = "./data/"
 
 describe("Repository tests", () => {
-    const t = new RepositoryClient("TestClient", "default")
+    const t = new RepositoryClient({ clientId: "TestClient", repository: "default" })
     t.loggingOn = true
 
     beforeEach("a", async function () {

--- a/packages/test/src/test/tests.ts
+++ b/packages/test/src/test/tests.ts
@@ -6,9 +6,9 @@ import { readModel } from "./utils.js"
 
 import { assert } from "chai"
 const { deepEqual, equal } = assert
-import sm from "source-map-support"
-
-sm.install()
+// import sm from "source-map-support"
+//
+// sm.install()
 const DATA: string = "./data/"
 
 const collection = [true, false]
@@ -17,7 +17,7 @@ const collection = [true, false]
 collection.forEach(withoutHistory => {
     const repository = withoutHistory ? "MyFirstRepo" : "MyFirstHistoryRepo"
     describe("Repository tests " + (withoutHistory ? "without history" : "with history"), () => {
-        const client = new RepositoryClient("TestClient", repository)
+        const client = new RepositoryClient({ clientId: "TestClient", repository: repository })
         // client.loggingOn = true
         let initialPartition: LionWebJsonChunk
         let initialPartitionVersion: number = 0

--- a/packages/test/src/test/tests.ts
+++ b/packages/test/src/test/tests.ts
@@ -6,9 +6,6 @@ import { readModel } from "./utils.js"
 
 import { assert } from "chai"
 const { deepEqual, equal } = assert
-// import sm from "source-map-support"
-//
-// sm.install()
 const DATA: string = "./data/"
 
 const collection = [true, false]


### PR DESCRIPTION
Added ClientConfig type, which is used to configure the bulk API client in its constructor.
It still has the old defaults and environment variables, but the ClientConfig object will override these.

